### PR TITLE
store block queue in local storage

### DIFF
--- a/chrome/script.js
+++ b/chrome/script.js
@@ -1,4 +1,42 @@
-import { ClearCache, DefaultOptions, SetOptions, HandleInstructionsResponse, HandleHomeTimeline } from '../shared.js';
+import { ClearCache, DefaultOptions, SetBlockQueue, SetOptions, HandleInstructionsResponse, HandleHomeTimeline } from '../shared.js';
+
+class BlockQueue {
+	// queue must be defined with push and shift functions
+	constructor() {
+		this.queue = [];
+		this.timeout = null;
+	}
+	async sync() {
+		// sync simply adds the in-memory queue to the stored queue
+		const items = await chrome.storage.local.get({ BlockQueue: [] });
+		items.BlockQueue.push(...this.queue);
+		await chrome.storage.local.set(items);
+		this.queue.length = 0;
+		this.timeout = null;
+	}
+	async push(item) {
+		this.queue.push(item);
+		if (this.timeout) {
+			clearTimeout(this.timeout);
+		}
+		this.timeout = setTimeout(() => this.sync(), 100);
+	}
+	async shift() {
+		// shift halts any modifications to the local storage queue, removes an item, and saves it, and restarts sync
+		if (this.timeout) {
+			clearTimeout(this.timeout);
+		}
+		const items = await chrome.storage.local.get({ BlockQueue: [] });
+		const item = items.BlockQueue.shift();
+		if (item !== undefined) {
+			await chrome.storage.local.set(items);
+		}
+		this.timeout = setTimeout(() => this.sync(), 100);
+		return item;
+	}
+}
+SetBlockQueue(new BlockQueue());
+
 
 document.addEventListener("blue-blocker-event", function (e) {
 	ClearCache();

--- a/chrome/script.js
+++ b/chrome/script.js
@@ -1,41 +1,5 @@
-import { ClearCache, DefaultOptions, SetBlockQueue, SetOptions, HandleInstructionsResponse, HandleHomeTimeline } from '../shared.js';
-
-class BlockQueue {
-	// queue must be defined with push and shift functions
-	constructor() {
-		this.queue = [];
-		this.timeout = null;
-	}
-	async sync() {
-		// sync simply adds the in-memory queue to the stored queue
-		const items = await chrome.storage.local.get({ BlockQueue: [] });
-		items.BlockQueue.push(...this.queue);
-		await chrome.storage.local.set(items);
-		this.queue.length = 0;
-		this.timeout = null;
-	}
-	async push(item) {
-		this.queue.push(item);
-		if (this.timeout) {
-			clearTimeout(this.timeout);
-		}
-		this.timeout = setTimeout(() => this.sync(), 100);
-	}
-	async shift() {
-		// shift halts any modifications to the local storage queue, removes an item, and saves it, and restarts sync
-		if (this.timeout) {
-			clearTimeout(this.timeout);
-		}
-		const items = await chrome.storage.local.get({ BlockQueue: [] });
-		const item = items.BlockQueue.shift();
-		if (item !== undefined) {
-			await chrome.storage.local.set(items);
-		}
-		this.timeout = setTimeout(() => this.sync(), 100);
-		return item;
-	}
-}
-SetBlockQueue(new BlockQueue());
+import { ClearCache, DefaultOptions, BlockQueue, SetBlockQueue, SetOptions, HandleInstructionsResponse, HandleHomeTimeline } from '../shared.js';
+SetBlockQueue(new BlockQueue(chrome.storage.local));
 
 
 document.addEventListener("blue-blocker-event", function (e) {

--- a/firefox/script.js
+++ b/firefox/script.js
@@ -1,41 +1,5 @@
-import { ClearCache, DefaultOptions, SetBlockQueue, SetOptions, HandleInstructionsResponse, HandleHomeTimeline } from '../shared.js';
-
-class BlockQueue {
-	// queue must be defined with push and shift functions
-	constructor() {
-		this.queue = [];
-		this.timeout = null;
-	}
-	async sync() {
-		// sync simply adds the in-memory queue to the stored queue
-		const items = await browser.storage.local.get({ BlockQueue: [] });
-		items.BlockQueue.push(...this.queue);
-		await browser.storage.local.set(items);
-		this.queue.length = 0;
-		this.timeout = null;
-	}
-	async push(item) {
-		this.queue.push(item);
-		if (this.timeout) {
-			clearTimeout(this.timeout);
-		}
-		this.timeout = setTimeout(() => this.sync(), 100);
-	}
-	async shift() {
-		// shift halts any modifications to the local storage queue, removes an item, and saves it, and restarts sync
-		if (this.timeout) {
-			clearTimeout(this.timeout);
-		}
-		const items = await browser.storage.local.get({ BlockQueue: [] });
-		const item = items.BlockQueue.shift();
-		if (item !== undefined) {
-			await browser.storage.local.set(items);
-		}
-		this.timeout = setTimeout(() => this.sync(), 100);
-		return item;
-	}
-}
-SetBlockQueue(new BlockQueue());
+import { ClearCache, DefaultOptions, BlockQueue, SetBlockQueue, SetOptions, HandleInstructionsResponse, HandleHomeTimeline } from '../shared.js';
+SetBlockQueue(new BlockQueue(browser.storage.local));
 
 
 document.addEventListener("blue-blocker-event", function (e) {

--- a/firefox/script.js
+++ b/firefox/script.js
@@ -1,4 +1,42 @@
-import { ClearCache, DefaultOptions, SetOptions, HandleInstructionsResponse, HandleHomeTimeline } from '../shared.js';
+import { ClearCache, DefaultOptions, SetBlockQueue, SetOptions, HandleInstructionsResponse, HandleHomeTimeline } from '../shared.js';
+
+class BlockQueue {
+	// queue must be defined with push and shift functions
+	constructor() {
+		this.queue = [];
+		this.timeout = null;
+	}
+	async sync() {
+		// sync simply adds the in-memory queue to the stored queue
+		const items = await browser.storage.local.get({ BlockQueue: [] });
+		items.BlockQueue.push(...this.queue);
+		await browser.storage.local.set(items);
+		this.queue.length = 0;
+		this.timeout = null;
+	}
+	async push(item) {
+		this.queue.push(item);
+		if (this.timeout) {
+			clearTimeout(this.timeout);
+		}
+		this.timeout = setTimeout(() => this.sync(), 100);
+	}
+	async shift() {
+		// shift halts any modifications to the local storage queue, removes an item, and saves it, and restarts sync
+		if (this.timeout) {
+			clearTimeout(this.timeout);
+		}
+		const items = await browser.storage.local.get({ BlockQueue: [] });
+		const item = items.BlockQueue.shift();
+		if (item !== undefined) {
+			await browser.storage.local.set(items);
+		}
+		this.timeout = setTimeout(() => this.sync(), 100);
+		return item;
+	}
+}
+SetBlockQueue(new BlockQueue());
+
 
 document.addEventListener("blue-blocker-event", function (e) {
 	ClearCache();

--- a/shared.js
+++ b/shared.js
@@ -80,7 +80,11 @@ const ReasonMap = {
 	[ReasonNftAvatar]: "NFT avatar",
 };
 
-const BlockQueue = [];
+var BlockQueue = null;
+export function SetBlockQueue(queue) {
+	BlockQueue = queue;
+}
+
 const BlockCache = new Set();
 let BlockInterval = undefined;
 
@@ -95,20 +99,22 @@ function QueueBlockUser(user, user_id, headers, reason) {
 	BlockCache.add(user_id);
 	BlockQueue.push({user, user_id, headers, reason});
 	console.log(`queued ${user.legacy.name} (@${user.legacy.screen_name}) for a block due to ${ReasonMap[reason]}.`);
-	
+
 	if (BlockInterval === undefined) {
 		BlockInterval = setInterval(CheckBlockQueue, 5000);
 	}
 }
 
 function CheckBlockQueue() {
-	if (BlockQueue.length === 0) {
-		clearInterval(BlockInterval);
-		BlockInterval = undefined;
-		return;
-	}
-	const {user, user_id, headers, reason} = BlockQueue.shift();
-	BlockUser(user, user_id, headers, reason);
+	BlockQueue.shift().then(item => {
+		if (item === undefined) {
+			clearInterval(BlockInterval);
+			BlockInterval = undefined;
+			return;
+		}
+		const {user, user_id, headers, reason} = item;
+		BlockUser(user, user_id, headers, reason);
+	});
 }
 
 function BlockUser(user, user_id, headers, reason, attempt=1) {

--- a/shared.js
+++ b/shared.js
@@ -80,9 +80,46 @@ const ReasonMap = {
 	[ReasonNftAvatar]: "NFT avatar",
 };
 
-var BlockQueue = null;
-export function SetBlockQueue(queue) {
-	BlockQueue = queue;
+export class BlockQueue {
+	// queue must be defined with push and shift functions
+	constructor(storage) {
+		this.storage = storage;
+		this.queue = [];
+		this.timeout = null;
+	}
+	async sync() {
+		// sync simply adds the in-memory queue to the stored queue
+		const items = await this.storage.get({ BlockQueue: [] });
+		items.BlockQueue.push(...this.queue);
+		await this.storage.set(items);
+		this.queue.length = 0;
+		this.timeout = null;
+	}
+	async push(item) {
+		this.queue.push(item);
+		if (this.timeout) {
+			clearTimeout(this.timeout);
+		}
+		this.timeout = setTimeout(() => this.sync(), 100);
+	}
+	async shift() {
+		// shift halts any modifications to the local storage queue, removes an item, and saves it, and restarts sync
+		if (this.timeout) {
+			clearTimeout(this.timeout);
+		}
+		const items = await this.storage.get({ BlockQueue: [] });
+		const item = items.BlockQueue.shift();
+		if (item !== undefined) {
+			await this.storage.set(items);
+		}
+		this.timeout = setTimeout(() => this.sync(), 100);
+		return item;
+	}
+}
+
+var queue = null;
+export function SetBlockQueue(q) {
+	queue = q;
 }
 
 const BlockCache = new Set();
@@ -97,7 +134,7 @@ function QueueBlockUser(user, user_id, headers, reason) {
 		return;
 	}
 	BlockCache.add(user_id);
-	BlockQueue.push({user, user_id, headers, reason});
+	queue.push({user, user_id, headers, reason});
 	console.log(`queued ${user.legacy.name} (@${user.legacy.screen_name}) for a block due to ${ReasonMap[reason]}.`);
 
 	if (BlockInterval === undefined) {
@@ -106,7 +143,7 @@ function QueueBlockUser(user, user_id, headers, reason) {
 }
 
 function CheckBlockQueue() {
-	BlockQueue.shift().then(item => {
+	queue.shift().then(item => {
 		if (item === undefined) {
 			clearInterval(BlockInterval);
 			BlockInterval = undefined;


### PR DESCRIPTION
this partially addresses [issue#16](https://github.com/kheina-com/Blue-Blocker/issues/16) by having the in-memory block queue sync to the local storage. this also allows the queue to be shared by tabs with a low risk of conflict