### PR TITLE
Fix Zero Followers Bug in skip1Mplus Option

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -210,7 +210,7 @@ export function BlockBlueVerified(user, headers) {
 		}
 		else if (
 			// verified by follower count
-			options.skip1Mplus && (user.legacy.followers_count > 1000000 || !user.legacy.followers_count)
+			options.skip1Mplus && user.legacy.followers_count > 1000000
 		) {
 			console.log(`did not block Twitter Blue verified user ${user.legacy.name} (@${user.legacy.screen_name}) because they have over a million followers and Elon is an idiot.`);
 		}


### PR DESCRIPTION
fixes a bug in the `skip1Mplus` option where accounts with zero followers were accidentally skipped as well. This PR fixes https://github.com/kheina-com/Blue-Blocker/issues/24