### PR TITLE
update makefile for no split platform folders

### DIFF
--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ firefox:
 
 	mv manifest.json chrome-manifest.json
 	mv firefox-manifest.json manifest.json
-	zip "blue-blocker-firefox-${VERSION}.zip" manifest.json LICENSE readme.md style.css inject.js shared.js assets/* firefox/*
+	zip "blue-blocker-firefox-${VERSION}.zip" manifest.json LICENSE readme.md popup.html style.css inject.js main.js options.js script.js service_worker.js shared.js assets/*
 	mv manifest.json firefox-manifest.json
 	mv chrome-manifest.json manifest.json
 
@@ -18,4 +18,4 @@ chrome:
 	# ifneq (,$(wildcard blue-blocker-chrome-$(VERSION).zip))
 	# 	rm "blue-blocker-chrome-${VERSION}.zip"
 	# endif
-	zip "blue-blocker-chrome-${VERSION}.zip" manifest.json LICENSE readme.md style.css inject.js shared.js assets/* chrome/*
+	zip "blue-blocker-chrome-${VERSION}.zip" manifest.json LICENSE readme.md popup.html style.css inject.js main.js options.js script.js service_worker.js shared.js assets/*


### PR DESCRIPTION
updates makefile for packing the zips correctly since there is no more firefox or chrome folders anymore

- [x] tested on chrome
- [x] tested on firefox