### PR TITLE
remove active tab requirement from manifests

### DIFF
--- a/firefox-manifest.json
+++ b/firefox-manifest.json
@@ -24,8 +24,7 @@
 		"default_icon": "assets/icon.png"
 	},
 	"permissions": [
-		"storage",
-		"activeTab"
+		"storage"
 	],
 	"content_scripts": [
 		{

--- a/manifest.json
+++ b/manifest.json
@@ -24,8 +24,7 @@
 		"default_icon": "assets/icon.png"
 	},
 	"permissions": [
-		"storage",
-		"activeTab"
+		"storage"
 	],
 	"content_scripts": [
 		{


### PR DESCRIPTION
realized I still had the active tab requirement in the manifests even though I removed the code that used it. this does not bump the version