### PR TITLE
Reset Firefox Manifest to Version 2

### DIFF
--- a/firefox-manifest.json
+++ b/firefox-manifest.json
@@ -1,5 +1,5 @@
 {
-	"manifest_version": 3,
+	"manifest_version": 2,
 	"name": "Blue Blocker",
 	"version": "0.2.3",
 	"description": "Blocks all Twitter Blue verified users on twitter.com",
@@ -7,21 +7,17 @@
 		"128": "assets/icon-128.png"
 	},
 	"web_accessible_resources": [
-		{
-			"resources": [
-				"script.js",
-				"shared.js",
-				"inject.js"
-			],
-			"matches": [
-				"*://*.twitter.com/*",
-				"*://twitter.com/*"
-			]
-		}
+		"script.js",
+		"shared.js",
+		"inject.js"
 	],
-	"action": {
-		"default_popup": "popup.html",
-		"default_icon": "assets/icon.png"
+	"browser_action": {
+		"browser_style": true,
+		"default_icon": {
+			"128": "assets/icon-128.png"
+		},
+		"default_title": "Blue Blocker",
+		"default_popup": "popup.html"
 	},
 	"permissions": [
 		"storage"

--- a/popup.html
+++ b/popup.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
-<html>
+<html lang='en'>
 	<head>
+		<meta charset='utf-8'/>
 		<title>Blue Blocker</title>
 		<link href="./style.css" rel="stylesheet">
 	</head>

--- a/service_worker.js
+++ b/service_worker.js
@@ -1,7 +1,16 @@
 // we can't import things from shared, so re-initialize the api
-const api = chrome || browser;
+let _api = null;
+try {
+	_api = browser;
+	// manifest v2 has the action api stored in browserAction, so manually assign it to action
+	_api.action = browser.browserAction;
+}
+catch (ReferenceError) {
+	_api = chrome;
+}
+const api = _api;
 
-export function abbreviate(value) {
+function abbreviate(value) {
 	if (value >= 1000000000)
 	{ return `${Math.round(value / 100000000) / 10}B`; }
 	if (value >= 1000000)

--- a/shared.js
+++ b/shared.js
@@ -1,12 +1,16 @@
-export const api = chrome || browser;
+let _api = null;
+try {
+	_api = browser;
+}
+catch (ReferenceError) {
+	_api = chrome;
+}
+export const api = _api;
 
 var s = document.createElement("script");
 s.src = api.runtime.getURL("inject.js");
 s.id = "injected-blue-block-xhr";
 s.type = "text/javascript";
-// s.onload = function() {
-// 	this.remove();
-// };
 (document.head || document.documentElement).appendChild(s);
 
 export const DefaultOptions = {


### PR DESCRIPTION
this PR addresses https://github.com/kheina-com/Blue-Blocker/issues/39

as described in the issue, firefox ESR releases do not support manifest V3 yet, so to maintain full support, revert firefox manifest version back to 2

- [x] tested on chrome
- [x] tested on firefox