### PR TITLE
Add instructions and matching for the SearchTimeline endpoint.

### DIFF
--- a/injected/inject.js
+++ b/injected/inject.js
@@ -1,5 +1,5 @@
 (function(xhr) {
-	const RequestRegex = /^https?:\/\/(?:\w+\.)?twitter.com\/[\w\/\.\-\_\=]+\/(HomeLatestTimeline|HomeTimeline|UserTweets|timeline\/home\.json|TweetDetail|search\/typeahead\.json|search\/adaptive\.json)(?:$|\?)/;
+	const RequestRegex = /^https?:\/\/(?:\w+\.)?twitter.com\/[\w\/\.\-\_\=]+\/(HomeLatestTimeline|HomeTimeline|SearchTimeline|UserTweets|timeline\/home\.json|TweetDetail|search\/typeahead\.json|search\/adaptive\.json)(?:$|\?)/;
 
 	let XHR = XMLHttpRequest.prototype;
 	let open = XHR.open;

--- a/parsers/instructions.js
+++ b/parsers/instructions.js
@@ -20,13 +20,13 @@ export const InstructionsPaths = {
 		"home_timeline_urt",
 		"instructions",
 	],
-  SearchTimeline: [
-    "data",
-    "search_by_raw_query",
-    "search_timeline",
-    "timeline",
-    "instructions",
-  ],
+	SearchTimeline: [
+		"data",
+		"search_by_raw_query",
+		"search_timeline",
+		"timeline",
+		"instructions",
+	],
 	UserTweets: [
 		"data",
 		"user",

--- a/parsers/instructions.js
+++ b/parsers/instructions.js
@@ -20,6 +20,13 @@ export const InstructionsPaths = {
 		"home_timeline_urt",
 		"instructions",
 	],
+  SearchTimeline: [
+    "data",
+    "search_by_raw_query",
+    "search_timeline",
+    "timeline",
+    "instructions",
+  ],
 	UserTweets: [
 		"data",
 		"user",

--- a/script.js
+++ b/script.js
@@ -38,6 +38,7 @@ document.addEventListener("blue-blocker-event", function (e) {
 			switch (e.detail.parsedUrl[1]) {
 				case "HomeLatestTimeline":
 				case "HomeTimeline":
+        case "SearchTimeline":
 				case "UserTweets":
 				case "TweetDetail":
 					return HandleInstructionsResponse(e, parsed_body, config);

--- a/script.js
+++ b/script.js
@@ -38,7 +38,7 @@ document.addEventListener("blue-blocker-event", function (e) {
 			switch (e.detail.parsedUrl[1]) {
 				case "HomeLatestTimeline":
 				case "HomeTimeline":
-        case "SearchTimeline":
+				case "SearchTimeline":
 				case "UserTweets":
 				case "TweetDetail":
 					return HandleInstructionsResponse(e, parsed_body, config);


### PR DESCRIPTION
Resolves #118

Looks like they added/changed the name of the search endpoint. First time looking through all of this, so even that I'm not sure of - all I know is that this fixes the problem.

It looks like there could be different search types, but I'm not sure how to adapt the current instructions key array format to fit that, so this just works for the most basic use case: searching by typing text in the box. It appears to still work fine for hashtags and cashtags and advanced search, and I can't even find another search type besides `search_by_raw_query`, so I think this is sufficient for now.

![2023-06-09_16:58:29](https://github.com/kheina-com/Blue-Blocker/assets/145945/d9fae526-60c3-4dfa-a423-27c79fb4c378)
