### PR TITLE
add quick and advanced tabs to the popup menu

### DIFF
--- a/makefile
+++ b/makefile
@@ -28,8 +28,8 @@ firefox:
 
 	cp LICENSE build/LICENSE
 	cp readme.md build/readme.md
-	cd build
-	zip "blue-blocker-firefox-${VERSION}.zip" *
+	cd build; zip "blue-blocker-firefox-${VERSION}.zip" -r *
+	mv "build/blue-blocker-firefox-${VERSION}.zip" "blue-blocker-firefox-${VERSION}.zip"
 
 .PHONY: chrome
 chrome:
@@ -39,5 +39,5 @@ chrome:
 
 	cp LICENSE build/LICENSE
 	cp readme.md build/readme.md
-	cd build
-	zip "blue-blocker-firefox-${VERSION}.zip" *
+	cd build; zip "blue-blocker-chrome-${VERSION}.zip" -r *
+	mv "build/blue-blocker-chrome-${VERSION}.zip" "blue-blocker-chrome-${VERSION}.zip"

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -22,7 +22,7 @@ export default defineManifest({
 			js: ["src/content/index.ts"],
 		},
 	],
-	permissions: ["storage", "unlimitedStorage", "management"],
+	permissions: ["storage", "unlimitedStorage"],
 	web_accessible_resources: [
 		{
 			resources: [

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -13,128 +13,191 @@
 		<span id="version"></span>
 		<h2><img src="/icon/icon.png" alt="🅱️" style="height: 1.2em">lue Blocker</h2>
 		<p class="blocked-users-count">blocked <span id="blocked-users-count"></span> users so far! (<span id="blocked-user-queue-length"></span> queued: <a href="/src/pages/queue/index.html" target="_blank">view</a>)</p>
-		<div class="option">
-			<input type="checkbox" id="suspend-block-collection">
-			<label ref="label" for="suspend-block-collection" >
-				<div class="checkmark">
-					<div></div>
-				</div>
-				<p>pause user collection</p>
-			</label>
-			<span id="suspend-block-collection-status"></span>
+		<div class="tabs">
+			<a id="button-basic">Basic<div class="border"></div></a>
+			<div class="separator"></div>
+			<a id="button-advanced">Advanced<div class="border"></div></a>
 		</div>
-		<div class="option">
-			<input type="checkbox" id="show-block-popups">
-			<label ref="label" for="show-block-popups" >
-				<div class="checkmark">
-					<div></div>
-				</div>
-				<p>show a popup for each blocked user</p>
-			</label>
-			<span id="show-block-popups-status"></span>
-		</div>
-		<div class="option">
-			<input type="checkbox" id="mute-instead-of-block">
-			<label ref="label" for="mute-instead-of-block" >
-				<div class="checkmark">
-					<div></div>
-				</div>
-				<p>mute users instead of blocking them</p>
-			</label>
-			<span id="mute-instead-of-block-status"></span>
-		</div>
-		<div class="option">
-			<input type="checkbox" id="block-following">
-			<label ref="label" for="block-following" >
-				<div class="checkmark">
-					<div></div>
-				</div>
-				<p>block people I follow</p>
-			</label>
-			<span id="block-following-status"></span>
-		</div>
-		<div class="option">
-			<input type="checkbox" id="block-followers">
-			<label ref="label" for="block-followers" >
-				<div class="checkmark">
-					<div></div>
-				</div>
-				<p>block people who follow me</p>
-			</label>
-			<span id="block-followers-status"></span>
-		</div>
-		<div class="option">
-			<input type="checkbox" id="skip-verified">
-			<label ref="label" for="skip-verified" >
-				<div class="checkmark">
-					<div></div>
-				</div>
-				<p>skip legacy verified users</p>
-			</label>
-			<span id="skip-verified-status"></span>
-		</div>
-		<div class="option">
-			<input type="checkbox" id="skip-affiliated">
-			<label ref="label" for="skip-affiliated" >
-				<div class="checkmark">
-					<div></div>
-				</div>
-				<p>skip users verified via businesses (<svg viewBox="0 0 22 22" role="img" class="gold-check" data-testid="icon-verified"><g><linearGradient gradientUnits="userSpaceOnUse" id="10-a" x1="4.411" x2="18.083" y1="2.495" y2="21.508"><stop offset="0" stop-color="#f4e72a"></stop><stop offset=".539" stop-color="#cd8105"></stop><stop offset=".68" stop-color="#cb7b00"></stop><stop offset="1" stop-color="#f4ec26"></stop><stop offset="1" stop-color="#f4e72a"></stop></linearGradient><linearGradient gradientUnits="userSpaceOnUse" id="10-b" x1="5.355" x2="16.361" y1="3.395" y2="19.133"><stop offset="0" stop-color="#f9e87f"></stop><stop offset=".406" stop-color="#e2b719"></stop><stop offset=".989" stop-color="#e2b719"></stop></linearGradient><g clip-rule="evenodd" fill-rule="evenodd"><path d="M13.324 3.848L11 1.6 8.676 3.848l-3.201-.453-.559 3.184L2.06 8.095 3.48 11l-1.42 2.904 2.856 1.516.559 3.184 3.201-.452L11 20.4l2.324-2.248 3.201.452.559-3.184 2.856-1.516L18.52 11l1.42-2.905-2.856-1.516-.559-3.184zm-7.09 7.575l3.428 3.428 5.683-6.206-1.347-1.247-4.4 4.795-2.072-2.072z" fill="url(#10-a)"></path><path d="M13.101 4.533L11 2.5 8.899 4.533l-2.895-.41-.505 2.88-2.583 1.37L4.2 11l-1.284 2.627 2.583 1.37.505 2.88 2.895-.41L11 19.5l2.101-2.033 2.895.41.505-2.88 2.583-1.37L17.8 11l1.284-2.627-2.583-1.37-.505-2.88zm-6.868 6.89l3.429 3.428 5.683-6.206-1.347-1.247-4.4 4.795-2.072-2.072z" fill="url(#10-b)"></path><path d="M6.233 11.423l3.429 3.428 5.65-6.17.038-.033-.005 1.398-5.683 6.206-3.429-3.429-.003-1.405.005.003z" fill="#d18800"></path></g></g></svg>)</p>
-			</label>
-			<span id="skip-affiliated-status"></span>
-		</div>
-		<div class="option">
-			<input type="checkbox" id="skip-1mplus">
-			<label ref="label" for="skip-1mplus" >
-				<div class="checkmark">
-					<div></div>
-				</div>
-				<p>skip users with over <span id="skip-follower-count-value">1M</span> followers</p>
-			</label>
-			<span id="skip-1mplus-status"></span>
-		</div>
-		<div class="option" id="skip-follower-count-option">
-			<p>threshold: <input id="skip-follower-count"> followers</p>
-			<span id="skip-follower-count-status"></span>
-		</div>
-		<div class="option">
-			<input type="checkbox" id="block-nft-avatars">
-			<label ref="label" for="block-nft-avatars" >
-				<div class="checkmark">
-					<div></div>
-				</div>
-				<p>block users with NFT avatars</p>
-			</label>
-			<span id="block-nft-avatars-status"></span>
-		</div>
-		<div class="option" id="soupcan-integration-option">
-			<input type="checkbox" id="soupcan-integration">
-			<label ref="label" for="soupcan-integration" >
-				<div class="checkmark">
-					<div></div>
-				</div>
-				<p>block transphobic users via Soupcan <img src="/icon/soupcan.png" alt="🥫" class="emoji"></p>
-			</label>
-			<span id="soupcan-integration-status"></span>
-		</div>
-		<div>
+		<div class="tab" id="basic">
 			<div class="option">
-				<p>block interval</p>
-				<span id="block-interval-status"></span>
+				<input type="checkbox" id="suspend-block-collection">
+				<label ref="label" for="suspend-block-collection" >
+					<div class="checkmark">
+						<div></div>
+					</div>
+					<p>pause user collection</p>
+				</label>
+				<span id="suspend-block-collection-status"></span>
 			</div>
-			<div class="slider">
-				<input type="range" min="5" max="60" value="15" id="block-interval">
-				<span id="block-interval-value"></span>
+			<div class="option">
+				<input type="checkbox" id="show-block-popups">
+				<label ref="label" for="show-block-popups" >
+					<div class="checkmark">
+						<div></div>
+					</div>
+					<p>show a popup for each blocked user</p>
+				</label>
+				<span id="show-block-popups-status"></span>
+			</div>
+			<div class="option">
+				<input type="checkbox" id="mute-instead-of-block">
+				<label ref="label" for="mute-instead-of-block" >
+					<div class="checkmark">
+						<div></div>
+					</div>
+					<p>mute users instead of blocking them</p>
+				</label>
+				<span id="mute-instead-of-block-status"></span>
+			</div>
+			<div class="option">
+				<input type="checkbox" id="skip-1mplus">
+				<label ref="label" for="skip-1mplus" >
+					<div class="checkmark">
+						<div></div>
+					</div>
+					<p>skip users with over <span id="skip-follower-count-value">1M</span> followers</p>
+				</label>
+				<span id="skip-1mplus-status"></span>
+			</div>
+			<div class="option" id="skip-follower-count-option">
+				<p>threshold: <input id="skip-follower-count"> followers</p>
+				<span id="skip-follower-count-status"></span>
+			</div>
+			<div>
+				<div class="option">
+					<p>block interval</p>
+					<span id="block-interval-status"></span>
+				</div>
+				<div class="slider">
+					<input type="range" min="5" max="60" value="15" id="block-interval">
+					<span id="block-interval-value"></span>
+				</div>
 			</div>
 		</div>
-		<div id="popup-timer-slider">
+		<div class="tab" id="advanced">
 			<div class="option">
-				<p>popup timer</p>
-				<span id="popup-timer-status"></span>
+				<input type="checkbox" id="suspend-block-collection">
+				<label ref="label" for="suspend-block-collection" >
+					<div class="checkmark">
+						<div></div>
+					</div>
+					<p>pause user collection</p>
+				</label>
+				<span id="suspend-block-collection-status"></span>
 			</div>
-			<div class="slider">
-				<input type="range" min="5" max="60" value="15" id="popup-timer">
-				<span id="popup-timer-value"></span>
+			<div class="option">
+				<input type="checkbox" id="show-block-popups">
+				<label ref="label" for="show-block-popups" >
+					<div class="checkmark">
+						<div></div>
+					</div>
+					<p>show a popup for each blocked user</p>
+				</label>
+				<span id="show-block-popups-status"></span>
+			</div>
+			<div class="option">
+				<input type="checkbox" id="mute-instead-of-block">
+				<label ref="label" for="mute-instead-of-block" >
+					<div class="checkmark">
+						<div></div>
+					</div>
+					<p>mute users instead of blocking them</p>
+				</label>
+				<span id="mute-instead-of-block-status"></span>
+			</div>
+			<div class="option">
+				<input type="checkbox" id="block-following">
+				<label ref="label" for="block-following" >
+					<div class="checkmark">
+						<div></div>
+					</div>
+					<p>block people I follow</p>
+				</label>
+				<span id="block-following-status"></span>
+			</div>
+			<div class="option">
+				<input type="checkbox" id="block-followers">
+				<label ref="label" for="block-followers" >
+					<div class="checkmark">
+						<div></div>
+					</div>
+					<p>block people who follow me</p>
+				</label>
+				<span id="block-followers-status"></span>
+			</div>
+			<div class="option">
+				<input type="checkbox" id="skip-verified">
+				<label ref="label" for="skip-verified" >
+					<div class="checkmark">
+						<div></div>
+					</div>
+					<p>skip legacy verified users</p>
+				</label>
+				<span id="skip-verified-status"></span>
+			</div>
+			<div class="option">
+				<input type="checkbox" id="skip-affiliated">
+				<label ref="label" for="skip-affiliated" >
+					<div class="checkmark">
+						<div></div>
+					</div>
+					<p>skip users verified via businesses (<svg viewBox="0 0 22 22" role="img" class="gold-check" data-testid="icon-verified"><g><linearGradient gradientUnits="userSpaceOnUse" id="10-a" x1="4.411" x2="18.083" y1="2.495" y2="21.508"><stop offset="0" stop-color="#f4e72a"></stop><stop offset=".539" stop-color="#cd8105"></stop><stop offset=".68" stop-color="#cb7b00"></stop><stop offset="1" stop-color="#f4ec26"></stop><stop offset="1" stop-color="#f4e72a"></stop></linearGradient><linearGradient gradientUnits="userSpaceOnUse" id="10-b" x1="5.355" x2="16.361" y1="3.395" y2="19.133"><stop offset="0" stop-color="#f9e87f"></stop><stop offset=".406" stop-color="#e2b719"></stop><stop offset=".989" stop-color="#e2b719"></stop></linearGradient><g clip-rule="evenodd" fill-rule="evenodd"><path d="M13.324 3.848L11 1.6 8.676 3.848l-3.201-.453-.559 3.184L2.06 8.095 3.48 11l-1.42 2.904 2.856 1.516.559 3.184 3.201-.452L11 20.4l2.324-2.248 3.201.452.559-3.184 2.856-1.516L18.52 11l1.42-2.905-2.856-1.516-.559-3.184zm-7.09 7.575l3.428 3.428 5.683-6.206-1.347-1.247-4.4 4.795-2.072-2.072z" fill="url(#10-a)"></path><path d="M13.101 4.533L11 2.5 8.899 4.533l-2.895-.41-.505 2.88-2.583 1.37L4.2 11l-1.284 2.627 2.583 1.37.505 2.88 2.895-.41L11 19.5l2.101-2.033 2.895.41.505-2.88 2.583-1.37L17.8 11l1.284-2.627-2.583-1.37-.505-2.88zm-6.868 6.89l3.429 3.428 5.683-6.206-1.347-1.247-4.4 4.795-2.072-2.072z" fill="url(#10-b)"></path><path d="M6.233 11.423l3.429 3.428 5.65-6.17.038-.033-.005 1.398-5.683 6.206-3.429-3.429-.003-1.405.005.003z" fill="#d18800"></path></g></g></svg>)</p>
+				</label>
+				<span id="skip-affiliated-status"></span>
+			</div>
+			<div class="option">
+				<input type="checkbox" id="skip-1mplus">
+				<label ref="label" for="skip-1mplus" >
+					<div class="checkmark">
+						<div></div>
+					</div>
+					<p>skip users with over <span id="skip-follower-count-value">1M</span> followers</p>
+				</label>
+				<span id="skip-1mplus-status"></span>
+			</div>
+			<div class="option" id="skip-follower-count-option">
+				<p>threshold: <input id="skip-follower-count"> followers</p>
+				<span id="skip-follower-count-status"></span>
+			</div>
+			<div class="option">
+				<input type="checkbox" id="block-nft-avatars">
+				<label ref="label" for="block-nft-avatars" >
+					<div class="checkmark">
+						<div></div>
+					</div>
+					<p>block users with NFT avatars</p>
+				</label>
+				<span id="block-nft-avatars-status"></span>
+			</div>
+			<div class="option" id="soupcan-integration-option">
+				<input type="checkbox" id="soupcan-integration">
+				<label ref="label" for="soupcan-integration" >
+					<div class="checkmark">
+						<div></div>
+					</div>
+					<p>block transphobic users via Soupcan <img src="/icon/soupcan.png" alt="🥫" class="emoji"></p>
+				</label>
+				<span id="soupcan-integration-status"></span>
+			</div>
+			<div>
+				<div class="option">
+					<p>block interval</p>
+					<span id="block-interval-status"></span>
+				</div>
+				<div class="slider">
+					<input type="range" min="5" max="60" value="15" id="block-interval">
+					<span id="block-interval-value"></span>
+				</div>
+			</div>
+			<div id="popup-timer-slider">
+				<div class="option">
+					<p>popup timer</p>
+					<span id="popup-timer-status"></span>
+				</div>
+				<div class="slider">
+					<input type="range" min="5" max="60" value="15" id="popup-timer">
+					<span id="popup-timer-value"></span>
+				</div>
 			</div>
 		</div>
 	</body>

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -66,8 +66,8 @@
 				<!-- <span name="skip-1mplus-status"></span> -->
 			</div>
 			<div class="skip-follower-count option" name="skip-follower-count-option">
-				<p>threshold: <input type="number" name="skip-follower-count"> followers</p>
-				<span name="skip-follower-count-status"></span>
+				<p>∟ threshold: <input type="number" name="skip-follower-count"> followers</p>
+				<!-- <span name="skip-follower-count-status"></span> -->
 			</div>
 			<div>
 				<div class="option">
@@ -154,7 +154,7 @@
 				<span name="skip-1mplus-status"></span>
 			</div>
 			<div class="skip-follower-count option" name="skip-follower-count-option">
-				<p>threshold: <input type="number" name="skip-follower-count"> followers</p>
+				<p>∟ threshold: <input type="number" name="skip-follower-count"> followers</p>
 				<span name="skip-follower-count-status"></span>
 			</div>
 			<div class="option">
@@ -166,7 +166,7 @@
 				</label>
 				<span name="block-nft-avatars-status"></span>
 			</div>
-			<div class="option" name="soupcan-integration-option">
+			<div class="integration option" name="soupcan-integration-option">
 				<label for="soupcan-integration" name="soupcan-integration">
 					<div class="checkmark">
 						<div></div>

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -14,189 +14,185 @@
 		<h2><img src="/icon/icon.png" alt="🅱️" style="height: 1.2em">lue Blocker</h2>
 		<p class="blocked-users-count">blocked <span id="blocked-users-count"></span> users so far! (<span id="blocked-user-queue-length"></span> queued: <a href="/src/pages/queue/index.html" target="_blank">view</a>)</p>
 		<div class="tabs">
-			<a id="button-basic">Basic<div class="border"></div></a>
+			<a id="button-quick">Quick<div class="border"></div></a>
 			<div class="separator"></div>
 			<a id="button-advanced">Advanced<div class="border"></div></a>
 		</div>
-		<div class="tab" id="basic">
+		<input type="checkbox" id="suspend-block-collection">
+		<input type="checkbox" id="show-block-popups">
+		<input type="checkbox" id="mute-instead-of-block">
+		<input type="checkbox" id="block-following">
+		<input type="checkbox" id="block-followers">
+		<input type="checkbox" id="skip-verified">
+		<input type="checkbox" id="skip-affiliated">
+		<input type="checkbox" id="skip-1mplus">
+		<input type="checkbox" id="block-nft-avatars">
+		<input type="checkbox" id="soupcan-integration">
+		<div class="tab" id="quick">
 			<div class="option">
-				<input type="checkbox" id="suspend-block-collection">
-				<label ref="label" for="suspend-block-collection" >
+				<label for="suspend-block-collection" name="suspend-block-collection">
 					<div class="checkmark">
 						<div></div>
 					</div>
 					<p>pause user collection</p>
 				</label>
-				<span id="suspend-block-collection-status"></span>
+				<span name="suspend-block-collection-status"></span>
 			</div>
 			<div class="option">
-				<input type="checkbox" id="show-block-popups">
-				<label ref="label" for="show-block-popups" >
+				<label for="show-block-popups" name="show-block-popups">
 					<div class="checkmark">
 						<div></div>
 					</div>
 					<p>show a popup for each blocked user</p>
 				</label>
-				<span id="show-block-popups-status"></span>
+				<!-- <span name="show-block-popups-status"></span> -->
 			</div>
 			<div class="option">
-				<input type="checkbox" id="mute-instead-of-block">
-				<label ref="label" for="mute-instead-of-block" >
+				<label for="mute-instead-of-block" name="mute-instead-of-block">
 					<div class="checkmark">
 						<div></div>
 					</div>
 					<p>mute users instead of blocking them</p>
 				</label>
-				<span id="mute-instead-of-block-status"></span>
+				<!-- <span name="mute-instead-of-block-status"></span> -->
 			</div>
 			<div class="option">
-				<input type="checkbox" id="skip-1mplus">
-				<label ref="label" for="skip-1mplus" >
+				<label for="skip-1mplus" name="skip-1mplus">
 					<div class="checkmark">
 						<div></div>
 					</div>
-					<p>skip users with over <span id="skip-follower-count-value">1M</span> followers</p>
+					<p>skip users with over <span name="skip-follower-count-value">1M</span> followers</p>
 				</label>
-				<span id="skip-1mplus-status"></span>
+				<!-- <span name="skip-1mplus-status"></span> -->
 			</div>
-			<div class="option" id="skip-follower-count-option">
-				<p>threshold: <input id="skip-follower-count"> followers</p>
-				<span id="skip-follower-count-status"></span>
+			<div class="skip-follower-count option" name="skip-follower-count-option">
+				<p>threshold: <input type="number" name="skip-follower-count"> followers</p>
+				<span name="skip-follower-count-status"></span>
 			</div>
 			<div>
 				<div class="option">
 					<p>block interval</p>
-					<span id="block-interval-status"></span>
+					<span name="block-interval-status"></span>
 				</div>
 				<div class="slider">
-					<input type="range" min="5" max="60" value="15" id="block-interval">
-					<span id="block-interval-value"></span>
+					<input type="range" min="5" max="60" value="15" name="block-interval">
+					<span name="block-interval-value"></span>
 				</div>
 			</div>
 		</div>
 		<div class="tab" id="advanced">
 			<div class="option">
-				<input type="checkbox" id="suspend-block-collection">
-				<label ref="label" for="suspend-block-collection" >
+				<label for="suspend-block-collection" name="suspend-block-collection">
 					<div class="checkmark">
 						<div></div>
 					</div>
 					<p>pause user collection</p>
 				</label>
-				<span id="suspend-block-collection-status"></span>
+				<span name="suspend-block-collection-status"></span>
 			</div>
 			<div class="option">
-				<input type="checkbox" id="show-block-popups">
-				<label ref="label" for="show-block-popups" >
+				<label for="show-block-popups" name="show-block-popups">
 					<div class="checkmark">
 						<div></div>
 					</div>
 					<p>show a popup for each blocked user</p>
 				</label>
-				<span id="show-block-popups-status"></span>
+				<span name="show-block-popups-status"></span>
 			</div>
 			<div class="option">
-				<input type="checkbox" id="mute-instead-of-block">
-				<label ref="label" for="mute-instead-of-block" >
+				<label for="mute-instead-of-block" name="mute-instead-of-block">
 					<div class="checkmark">
 						<div></div>
 					</div>
 					<p>mute users instead of blocking them</p>
 				</label>
-				<span id="mute-instead-of-block-status"></span>
+				<span name="mute-instead-of-block-status"></span>
 			</div>
 			<div class="option">
-				<input type="checkbox" id="block-following">
-				<label ref="label" for="block-following" >
+				<label for="block-following" name="block-following">
 					<div class="checkmark">
 						<div></div>
 					</div>
 					<p>block people I follow</p>
 				</label>
-				<span id="block-following-status"></span>
+				<span name="block-following-status"></span>
 			</div>
 			<div class="option">
-				<input type="checkbox" id="block-followers">
-				<label ref="label" for="block-followers" >
+				<label for="block-followers" name="block-followers">
 					<div class="checkmark">
 						<div></div>
 					</div>
 					<p>block people who follow me</p>
 				</label>
-				<span id="block-followers-status"></span>
+				<span name="block-followers-status"></span>
 			</div>
 			<div class="option">
-				<input type="checkbox" id="skip-verified">
-				<label ref="label" for="skip-verified" >
+				<label for="skip-verified" name="skip-verified">
 					<div class="checkmark">
 						<div></div>
 					</div>
 					<p>skip legacy verified users</p>
 				</label>
-				<span id="skip-verified-status"></span>
+				<span name="skip-verified-status"></span>
 			</div>
 			<div class="option">
-				<input type="checkbox" id="skip-affiliated">
-				<label ref="label" for="skip-affiliated" >
+				<label for="skip-affiliated" name="skip-affiliated">
 					<div class="checkmark">
 						<div></div>
 					</div>
 					<p>skip users verified via businesses (<svg viewBox="0 0 22 22" role="img" class="gold-check" data-testid="icon-verified"><g><linearGradient gradientUnits="userSpaceOnUse" id="10-a" x1="4.411" x2="18.083" y1="2.495" y2="21.508"><stop offset="0" stop-color="#f4e72a"></stop><stop offset=".539" stop-color="#cd8105"></stop><stop offset=".68" stop-color="#cb7b00"></stop><stop offset="1" stop-color="#f4ec26"></stop><stop offset="1" stop-color="#f4e72a"></stop></linearGradient><linearGradient gradientUnits="userSpaceOnUse" id="10-b" x1="5.355" x2="16.361" y1="3.395" y2="19.133"><stop offset="0" stop-color="#f9e87f"></stop><stop offset=".406" stop-color="#e2b719"></stop><stop offset=".989" stop-color="#e2b719"></stop></linearGradient><g clip-rule="evenodd" fill-rule="evenodd"><path d="M13.324 3.848L11 1.6 8.676 3.848l-3.201-.453-.559 3.184L2.06 8.095 3.48 11l-1.42 2.904 2.856 1.516.559 3.184 3.201-.452L11 20.4l2.324-2.248 3.201.452.559-3.184 2.856-1.516L18.52 11l1.42-2.905-2.856-1.516-.559-3.184zm-7.09 7.575l3.428 3.428 5.683-6.206-1.347-1.247-4.4 4.795-2.072-2.072z" fill="url(#10-a)"></path><path d="M13.101 4.533L11 2.5 8.899 4.533l-2.895-.41-.505 2.88-2.583 1.37L4.2 11l-1.284 2.627 2.583 1.37.505 2.88 2.895-.41L11 19.5l2.101-2.033 2.895.41.505-2.88 2.583-1.37L17.8 11l1.284-2.627-2.583-1.37-.505-2.88zm-6.868 6.89l3.429 3.428 5.683-6.206-1.347-1.247-4.4 4.795-2.072-2.072z" fill="url(#10-b)"></path><path d="M6.233 11.423l3.429 3.428 5.65-6.17.038-.033-.005 1.398-5.683 6.206-3.429-3.429-.003-1.405.005.003z" fill="#d18800"></path></g></g></svg>)</p>
 				</label>
-				<span id="skip-affiliated-status"></span>
+				<span name="skip-affiliated-status"></span>
 			</div>
 			<div class="option">
-				<input type="checkbox" id="skip-1mplus">
-				<label ref="label" for="skip-1mplus" >
+				<label for="skip-1mplus" name="skip-1mplus">
 					<div class="checkmark">
 						<div></div>
 					</div>
-					<p>skip users with over <span id="skip-follower-count-value">1M</span> followers</p>
+					<p>skip users with over <span name="skip-follower-count-value">1M</span> followers</p>
 				</label>
-				<span id="skip-1mplus-status"></span>
+				<span name="skip-1mplus-status"></span>
 			</div>
-			<div class="option" id="skip-follower-count-option">
-				<p>threshold: <input id="skip-follower-count"> followers</p>
-				<span id="skip-follower-count-status"></span>
+			<div class="skip-follower-count option" name="skip-follower-count-option">
+				<p>threshold: <input type="number" name="skip-follower-count"> followers</p>
+				<span name="skip-follower-count-status"></span>
 			</div>
 			<div class="option">
-				<input type="checkbox" id="block-nft-avatars">
-				<label ref="label" for="block-nft-avatars" >
+				<label for="block-nft-avatars" name="block-nft-avatars">
 					<div class="checkmark">
 						<div></div>
 					</div>
 					<p>block users with NFT avatars</p>
 				</label>
-				<span id="block-nft-avatars-status"></span>
+				<span name="block-nft-avatars-status"></span>
 			</div>
-			<div class="option" id="soupcan-integration-option">
-				<input type="checkbox" id="soupcan-integration">
-				<label ref="label" for="soupcan-integration" >
+			<div class="option" name="soupcan-integration-option">
+				<label for="soupcan-integration" name="soupcan-integration">
 					<div class="checkmark">
 						<div></div>
 					</div>
 					<p>block transphobic users via Soupcan <img src="/icon/soupcan.png" alt="🥫" class="emoji"></p>
 				</label>
-				<span id="soupcan-integration-status"></span>
+				<span name="soupcan-integration-status"></span>
 			</div>
 			<div>
 				<div class="option">
 					<p>block interval</p>
-					<span id="block-interval-status"></span>
+					<span name="block-interval-status"></span>
 				</div>
 				<div class="slider">
-					<input type="range" min="5" max="60" value="15" id="block-interval">
-					<span id="block-interval-value"></span>
+					<input type="range" min="5" max="60" value="15" name="block-interval">
+					<span name="block-interval-value"></span>
 				</div>
 			</div>
-			<div id="popup-timer-slider">
+			<div name="popup-timer-slider">
 				<div class="option">
 					<p>popup timer</p>
-					<span id="popup-timer-status"></span>
+					<span name="popup-timer-status"></span>
 				</div>
 				<div class="slider">
-					<input type="range" min="5" max="60" value="15" id="popup-timer">
-					<span id="popup-timer-value"></span>
+					<input type="range" min="5" max="60" value="15" name="popup-timer">
+					<span name="popup-timer-value"></span>
 				</div>
 			</div>
 		</div>

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -216,7 +216,7 @@ document.addEventListener("DOMContentLoaded", () => {
 		if (!r) {
 			throw new Error("extension not enabled");
 		}
-		document.getElementsByName("soupcan-integration-option").forEach(e => e.style.display = "block");
+		document.getElementsByName("soupcan-integration-option").forEach(e => e.style.display = "flex");
 	}).catch((e: Error) => {
 		console.debug(logstr, "soupcan response for @elonmusk:", e);
 		document.getElementsByName("soupcan-integration-option").forEach(ele => ele.style.display = "none");

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -7,6 +7,48 @@ document.addEventListener("DOMContentLoaded", () => {
 	const version = document.getElementById("version") as HTMLElement;
 	version.textContent = "v" + api.runtime.getManifest().version;
 
+	const basicTabButton = document.getElementById("button-basic") as HTMLElement;
+	const advancedTabButton = document.getElementById("button-advanced") as HTMLElement;
+
+	const basicTabContent = document.getElementById("basic") as HTMLElement;
+	const advancedTabContent = document.getElementById("advanced") as HTMLElement;
+
+	function selectTab(tab: string) {
+		const basicTabButtonBorder = basicTabButton.lastChild as HTMLElement;
+		const advancedTabButtonBorder = advancedTabButton.lastChild as HTMLElement;
+
+		switch (tab) {
+			case "basic":
+				basicTabButtonBorder.style.borderBottomWidth = "5px";
+				advancedTabButtonBorder.style.borderBottomWidth = "0";
+
+				basicTabContent.style.display = "block";
+				advancedTabContent.style.display = "none";
+				break;
+
+			case "advanced":
+				basicTabButtonBorder.style.borderBottomWidth = "0";
+				advancedTabButtonBorder.style.borderBottomWidth = "5px";
+
+				basicTabContent.style.display = "none";
+				advancedTabContent.style.display = "block";
+				break;
+
+			default:
+				throw new Error("invalid button value. must be one of: 'basic', 'advanced'.");
+		}
+
+		api.storage.local.set({
+			popupActiveTab: tab,
+		}).then(() => {
+			console.debug(logstr, "set active tab:", tab);
+		});
+	}
+
+	api.storage.local.get({ popupActiveTab: "basic" }).then(items => selectTab(items.popupActiveTab));
+	basicTabButton.addEventListener("click", () => selectTab("basic"));
+	advancedTabButton.addEventListener("click", () => selectTab("advanced"));
+
 	const blockedUsersCount = document.getElementById("blocked-users-count") as HTMLElement;
 	const blockedUserQueueLength = document.getElementById("blocked-user-queue-length") as HTMLElement;
 	const suspendBlockCollection = document.getElementById("suspend-block-collection") as HTMLInputElement;

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -26,6 +26,14 @@ function checkHandler(target: HTMLInputElement, config: Config, key: string, opt
 		api.storage.sync.set({
 			[key]: target.checked,
 		}).then(() => (options.callback ?? (_ => {
+			document.getElementsByName(target.id + "-status").forEach(status => {
+				status.textContent = statusText;
+				setTimeout(() => status.textContent = null, 1000);
+			});
+			document.getElementsByName(optionName)
+			.forEach(e => e.style.display = target.checked ? "" : "none");
+		}))(target)).then(() => {
+			// update the checkmark last so that it can be used as the saved status indicator
 			ele.forEach(label => {
 				if (target.checked) {
 					label.classList.add("checked");
@@ -33,15 +41,7 @@ function checkHandler(target: HTMLInputElement, config: Config, key: string, opt
 					label.classList.remove("checked");
 				}
 			});
-
-			document.getElementsByName(target.id + "-status").forEach(status => {
-				status.textContent = statusText;
-				setTimeout(() => status.textContent = null, 1000);
-			});
-
-			document.getElementsByName(optionName)
-			.forEach(e => e.style.display = target.checked ? "" : "none");
-		}))(target));
+		});
 	});
 }
 

--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -116,7 +116,7 @@ h2 img {
 	width: var(--border-size);
 }
 .tabs a {
-	padding: 20px 25px;
+	padding: 1em 1.5em;
 	position: relative;
 	flex: 1;
 	text-align: center;
@@ -159,14 +159,18 @@ h2 img {
 	vertical-align: middle;
 }
 
+.option {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
 .option p {
 	text-align: center;
 	margin: 0;
 }
 
-.option {
-	display: flex;
-	justify-content: space-between;
+.integration {
+	display: none;
 }
 
 input[type="checkbox"] {
@@ -242,8 +246,10 @@ label.checked div.checkmark div {
 	transform: rotate(45deg);
 }
 
-.skip-follower-count.option {
-	margin-left: 2em;
+.skip-follower-count.option,
+.block-promoted-tweets.option {
+	margin-left: 0.5em;
+	margin-top: -0.5em;
 }
 
 input::-webkit-outer-spin-button,

--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -27,20 +27,32 @@ html * {
 	font-family: Bitstream Vera Sans, DejaVu Sans, Arial, Helvetica, sans-serif;
 }
 html, body {
-	background: var(--bg1color);
+	background: var(--bg2color);
 	color: var(--textcolor);
 }
 body {
-	width: 25em;
-	margin: 25px;
+	margin: 0;
 	padding: 0;
 	font-size: 1.1rem;
 }
-body > div {
-	margin-bottom: 1em;
+
+a,
+input,
+label,
+textarea {
+	cursor: pointer;
+	pointer-events: all;
+	text-decoration: none;
+	-webkit-transition: var(--transition) var(--fadetime);
+	-moz-transition: var(--transition) var(--fadetime);
+	-o-transition: var(--transition) var(--fadetime);
+	transition: var(--transition) var(--fadetime);
 }
-body > div:last-child, .last {
-	margin-bottom: 0;
+a:link, a:visited
+{ color: var(--textcolor); }
+a:hover {
+	color: var(--interact) !important;
+	opacity: 1 !important;
 }
 
 ::-webkit-scrollbar {
@@ -73,7 +85,7 @@ body > div:last-child, .last {
 
 /* popup title */
 h2 {
-	margin: 0;
+	margin: 1em 0 0;
 	text-align: center;
 }
 /* Blue Blocker logo in the popup title */
@@ -81,24 +93,57 @@ h2 img {
 	height: 1.2em !important; /* overwrite inline style that was added for development */
 	margin-bottom: -0.15em;
 }
+/* blocked users and queue subtitle */
+.blocked-users-count {
+	text-align: center;
+	color: var(--subtle);
+	font-size: 0.9em;
+	margin-top: 0;
+	margin-bottom: 0.25em;
+}
 
-a,
-input,
-label,
-textarea {
-	cursor: pointer;
-	pointer-events: all;
-	text-decoration: none;
+.tabs {
+	display: flex;
+	border-bottom: solid var(--border-size) var(--bordercolor);
+}
+.tabs .separator {
+	background: var(--bordercolor);
+	width: var(--border-size);
+}
+.tabs a {
+	padding: 20px 25px;
+	position: relative;
+	flex: 1;
+	text-align: center;
+}
+.tabs .border {
+	position: absolute;
+	width: 100%;
+	left: 0;
+	bottom: 0;
 	-webkit-transition: var(--transition) var(--fadetime);
 	-moz-transition: var(--transition) var(--fadetime);
 	-o-transition: var(--transition) var(--fadetime);
 	transition: var(--transition) var(--fadetime);
+	border-bottom: solid 0 var(--interact);
 }
-a:link, a:visited
-{ color: var(--textcolor); }
-a:hover {
-	color: var(--interact) !important;
-	opacity: 1 !important;
+
+.tab {
+	background: var(--bg1color);
+	margin: 0;
+	padding: 1em 25px 25px;
+}
+.tab > div {
+	margin-bottom: 1em;
+}
+.tab > div:last-child, .last {
+	margin-bottom: 0;
+}
+.tab#basic {
+	width: 20em;
+}
+.tab#advanced {
+	width: 30em;
 }
 
 .emoji {
@@ -226,14 +271,6 @@ input#skip-follower-count:focus {
 	margin: -0.2em 0;
 	width: 1.2em;
 	height: 1.2em;
-}
-
-.blocked-users-count {
-	text-align: center;
-	color: var(--subtle);
-	font-size: 0.9em;
-	margin-top: 0;
-	margin-bottom: 2em;
 }
 
 .slider {

--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -103,8 +103,13 @@ h2 img {
 }
 
 .tabs {
+	background: var(--bg2color);
+	position: -webkit-sticky;
+	position: sticky;
+	top: 0;
 	display: flex;
 	border-bottom: solid var(--border-size) var(--bordercolor);
+	z-index: 1000;
 }
 .tabs .separator {
 	background: var(--bordercolor);
@@ -139,11 +144,11 @@ h2 img {
 .tab > div:last-child, .last {
 	margin-bottom: 0;
 }
-.tab#basic {
-	width: 20em;
+.tab#quick {
+	min-width: 20em;
 }
 .tab#advanced {
-	width: 30em;
+	min-width: 27em;
 }
 
 .emoji {
@@ -237,10 +242,18 @@ label.checked div.checkmark div {
 	transform: rotate(45deg);
 }
 
-#skip-follower-count-option {
+.skip-follower-count.option {
 	margin-left: 2em;
 }
-input#skip-follower-count {
+
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+	-webkit-appearance: none;
+	margin: 0;
+}
+input[type=number] {
+	-moz-appearance: textfield;
+	appearance: textfield;
 	text-align: right;
 	width: 7em;
 	height: 1em;
@@ -258,12 +271,12 @@ input#skip-follower-count {
 	-o-transition: var(--transition) var(--fadetime);
 	transition: var(--transition) var(--fadetime);
 }
-input#skip-follower-count:hover {
+input[type=number]:hover {
 	color: var(--interact);
 	border-color: var(--borderhover);
 	box-shadow: 0 0 10px 3px var(--activeshadowcolor);
 }
-input#skip-follower-count:focus {
+input[type=number]:focus {
 	color: var(--textcolor);
 }
 


### PR DESCRIPTION
addresses #141, also addresses #155

the quickmenu only has 5 or 6 options in it and does not scroll. advanced menu has everything in it and will be where new options are added from now on.

to add a new checkbox option, follow the existing format in the html:
```html
<div class="option">
	<label for="skip-verified" name="skip-verified">
		<div class="checkmark">
			<div></div>
		</div>
		<p>skip legacy verified users</p>
	</label>
	<span name="skip-verified-status"></span>
</div>
```
status can be omitted on the quick page

and then registered on the backend like this:
```typescript
// custom callback
checkHandler(suspendBlockCollection, config, "suspendedBlockCollection", {
	callback(target) {
		// notice you need to update status yourself
		document.getElementsByName(target.id + "-status").forEach(status => {
			status.textContent = target.checked ? "paused" : "resumed";
			setTimeout(() => status.textContent = null, 1000);
		});
		api.action.setIcon({ path: target.checked ? "/icon/icon-128-greyscale.png" : "/icon/icon-128.png" });
	},
});
// custom option name
checkHandler(showBlockPopups, config, "showBlockPopups", {
	optionName: "popup-timer-slider",
});
// default everything
checkHandler(skipVerified, config, "skipVerified");
```
where the third value is the config key. if there are nested options, make sure they're labelled with `name="<check input id>-option"` and they will be hidden/shown automatically, or you can pass `optionName` to the checkHandler

you can also pass a custom callback to the checkHandler as well if you need to do something other than the normal updating status

![image](https://github.com/kheina-com/Blue-Blocker/assets/29378233/f3f904a9-bc46-456f-8309-088d5d4d770b)
![image](https://github.com/kheina-com/Blue-Blocker/assets/29378233/8d7564bf-f8ba-4561-b1cb-c68223d47025)
