### PR TITLE
feat: add OldTwitter support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blue-blocker",
-	"version": "0.3.7",
+	"version": "0.3.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blue-blocker",
-			"version": "0.3.7",
+			"version": "0.3.8",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@crxjs/vite-plugin": "^1.0.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blue-blocker",
-	"version": "0.3.7",
+	"version": "0.3.8",
 	"author": "DanielleMiu",
 	"description": "Blocks all Twitter Blue verified users on twitter.com",
 	"type": "module",

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -58,3 +58,27 @@ document.addEventListener("blue-blocker-event", function (e: CustomEvent<BlueBlo
 		}
 	});
 });
+
+// Add support for OldTwitter requests.
+window.addEventListener('message', function (ev) {
+	if (ev.data.type !== 'OLDTWITTER_REQUEST_LOAD') return;
+	if (!ev.data.url || !ev.data.body || !ev.data.headers)
+		return console.error(logstr, 'OldTwitter sent an invalid payload.', ev.data);
+
+	const body_str = JSON.stringify(ev.data.body);
+
+	document.dispatchEvent(
+		new CustomEvent('blue-blocker-event', {
+			detail: {
+				parsedUrl: /(.+)/.exec(ev.data.url)!, // Have to turn the endpoint string into a regex result...
+				url: ev.data.url,
+				body: body_str as XMLHttpRequest['response'],
+				request: {
+					headers: ev.data.headers,
+				},
+				// OldTwitter only emits messages on success.
+				status: 200,
+			},
+		}),
+	);
+});

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -3,7 +3,7 @@ import { defineManifest } from "@crxjs/vite-plugin";
 export default defineManifest({
 	name: "Blue Blocker",
 	description: "Blocks all Twitter Blue verified users on twitter.com",
-	version: "0.3.7",
+	version: "0.3.8",
 	manifest_version: 3,
 	icons: {
 		"128": "icon/icon-128.png",

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -645,27 +645,3 @@ export async function BlockBlueVerified(user: BlueBlockerUser, config: Config) {
 		}
 	}
 }
-
-// Add support for OldTwitter requests.
-window.addEventListener('message', function (ev) {
-	if (ev.data.type !== 'OLDTWITTER_REQUEST_LOAD') return;
-	if (!ev.data.url || !ev.data.body || !ev.data.headers)
-		return console.error(logstr, 'OldTwitter sent an invalid payload.', ev.data);
-
-	const body_str = JSON.stringify(ev.data.body);
-
-	document.dispatchEvent(
-		new CustomEvent('blue-blocker-event', {
-			detail: {
-				parsedUrl: /(.+)/.exec(ev.data.url)!, // Have to turn the endpoint string into a regex result...
-				url: ev.data.url,
-				body: body_str as XMLHttpRequest['response'],
-				request: {
-					headers: ev.data.headers,
-				},
-				// OldTwitter only emits messages on success.
-				status: 200,
-			},
-		}),
-	);
-});

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -26,7 +26,6 @@ import {
 	MakeToast,
 	RemoveUserBlockHistory,
 } from './utilities';
-import { ParseTimelineTweet } from './parsers/instructions';
 
 // TODO: tbh this file shouldn't even exist anymore and should be
 // split between content/startup.ts and utilities.ts

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -654,29 +654,18 @@ window.addEventListener('message', function (ev) {
 
 	const body_str = JSON.stringify(ev.data.body);
 
-	api.storage.sync
-		.get(DefaultOptions)
-		.then((_config) => {
-			const config = _config as Config;
-
-			document.dispatchEvent(
-				new CustomEvent('blue-blocker-event', {
-					detail: {
-						parsedUrl: /(.+)/.exec(ev.data.url)!, // Have to turn the endpoint string into a regex result...
-						url: ev.data.url,
-						body: body_str as XMLHttpRequest['response'],
-						request: {
-							headers: ev.data.headers,
-						},
-						// OldTwitter only emits messages on success.
-						status: 200,
-					},
-				}),
-			);
-
-			ParseTimelineTweet(ev.data, config);
-		})
-		.catch((err) => {
-			console.error(logstr, 'unexpected error occurred while processing OldTwitter request:', err);
-		});
+	document.dispatchEvent(
+		new CustomEvent('blue-blocker-event', {
+			detail: {
+				parsedUrl: /(.+)/.exec(ev.data.url)!, // Have to turn the endpoint string into a regex result...
+				url: ev.data.url,
+				body: body_str as XMLHttpRequest['response'],
+				request: {
+					headers: ev.data.headers,
+				},
+				// OldTwitter only emits messages on success.
+				status: 200,
+			},
+		}),
+	);
 });


### PR DESCRIPTION
This PR adds support for OldTwitter, and resolves #185

Support for this was added in https://github.com/dimdenGD/OldTwitter/pull/703 (auth fix in https://github.com/dimdenGD/OldTwitter/pull/704)

## Changelog
- Added an event listener to shared.ts that listens for `OLDTWITTER_REQUEST_LOAD` requests
- This then emits `blue-blocker-event`s containing the OldTwitter request information

## Deployment Checklist
1. [ ] merge all pull requests to llb
2. [ ] ensure `src/manifest.ts` and `package.json` have the correct version number
3. [x] use makefile to generate zips (`make chrome`, `make firefox`)
    - [ ] chrome should be tested with `npm run build`
    - [ ] test firefox locally using zip
4. [ ] merge llb to main
5. [ ] upload zips from `3` to chrome webstore and firefox addons
