### PR TITLE
Fix typeahead error in DM composer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blue-blocker",
-	"version": "0.3.8",
+	"version": "0.3.9",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blue-blocker",
-			"version": "0.3.8",
+			"version": "0.3.9",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@crxjs/vite-plugin": "^1.0.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blue-blocker",
-	"version": "0.3.8",
+	"version": "0.3.9",
 	"author": "DanielleMiu",
 	"description": "Blocks all Twitter Blue verified users on twitter.com",
 	"type": "module",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -3,7 +3,7 @@ import { defineManifest } from "@crxjs/vite-plugin";
 export default defineManifest({
 	name: "Blue Blocker",
 	description: "Blocks all Twitter Blue verified users on twitter.com",
-	version: "0.3.8",
+	version: "0.3.9",
 	manifest_version: 3,
 	icons: {
 		"128": "icon/icon-128.png",

--- a/src/parsers/search.ts
+++ b/src/parsers/search.ts
@@ -15,8 +15,8 @@ export function HandleTypeahead(e: CustomEvent<BlueBlockerEvent>, body: Body, co
 				is_blue_verified: user.ext_is_blue_verified,
 				legacy: {
 					blocking: user?.is_blocked || false,
-					followed_by: user.social_context.followed_by,
-					following: user.social_context.following,
+					followed_by: user?.social_context.followed_by || false,
+					following: user?.social_context.following || false,
 					name: user.name,
 					screen_name: user.screen_name,
 					verified: user.verified,


### PR DESCRIPTION
No idea what semver string to use here! 

## Changelog
- [FIX] Error involving typeahead in DM composer, close #189 

## Deployment Checklist
2. [ ] ensure `src/manifest.ts` and `package.json` have the correct version number
3. [ ] use makefile to generate zips (`make chrome`, `make firefox`)
    - [x] chrome should be tested with `npm run build`
    - [ ] test firefox locally using zip
4. [ ] merge llb to main
5. [ ] upload zips from `3` to chrome webstore and firefox addons
