### PR TITLE
Automate bumping manifest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "blue-blocker",
-			"version": "0.3.9",
+			"version": "0.4.1",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@crxjs/vite-plugin": "^1.0.14",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,11 @@
 		"dev": "vite",
 		"build": "tsc && vite build",
 		"preview": "vite preview",
-		"fmt": "prettier --write **/*.{ts,json,css,scss,md}"
+		"fmt": "prettier --write **/*.{ts,json,css,scss,md}",
+		"version": "node -e \"const fs = require('fs').promises; fs.readFile('./src/manifest.ts','utf-8').then(oldManifest => oldManifest.replace(/(?:\\d+\\.){2}(?:\\d)(?:-[\\w\\d\\-\\.]*)?/, process.env.npm_package_version)).then(newManifest => fs.writeFile('./src/manifest.ts', newManifest, 'utf-8'))\" && git add ./src/manifest.ts ./package*.json && echo updated manifest, new version:"
+	},
+	"config": {
+		"git-tag-version": false
 	},
 	"engines": {
 		"node": ">=18.16.0"


### PR DESCRIPTION
Just run `npm version`, it's that easy! A 144444.99 dollar value that you get for the low low price of me losing my mind looking at npm man pages

## Changelog
- Add a version script that gets run when `npm version` runs
  - That shit looks so ugly, i'm sooooo sorry. I didn't want to add a new file just for a goofy code chore
- Add config to package.json
  - I set it so it won't make commits with the message "v<SemVer string>", that would be really annoying! It's also set so that we don't have a spam of tags that get fucky after squash and merges