### PR TITLE
[fix] change condition for checking legacy if user used blue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blue-blocker",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blue-blocker",
-			"version": "0.4.1",
+			"version": "0.4.2",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@crxjs/vite-plugin": "^1.0.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blue-blocker",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"author": "DanielleMiu",
 	"description": "Blocks all Twitter Blue verified users on twitter.com",
 	"type": "module",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -3,7 +3,7 @@ import { defineManifest } from "@crxjs/vite-plugin";
 export default defineManifest({
 	name: "Blue Blocker",
 	description: "Blocks all Twitter Blue verified users on twitter.com",
-	version: "0.4.1",
+	version: "0.4.2",
 	manifest_version: 3,
 	icons: {
 		"128": "icon/icon-128.png",


### PR DESCRIPTION
I did an oopsie whoopsie and flipped the logic in my brain!! It should now load the legacy database if config.blockForUse is true and user.used_blue is false, instead of if both are true

Note: this PR will merge into the 0.4.2 LLB, see #267 for the aggregating PR