### PR TITLE
[fix] remove reference to chrome.runtime.restartAfterDelay

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,9 +7,7 @@ try {
 	_api = {
 		// @ts-ignore
 		runtime: {
-			...browser.runtime,
-			OnInstalledReason: chrome.runtime.OnInstalledReason,
-			restartAfterDelay: chrome.runtime.restartAfterDelay,
+			...browser.runtime
 		},
 		storage: browser.storage,
 		action: browser.browserAction,


### PR DESCRIPTION
See title. We literally never use it, but it causes an incompatibility warning with Firefox.

Note: this is a PR against the 0.4.2 LLB. See #267 for the PR that aggregates changes to be applied to main.