### PR TITLE
[Feat] Add the ability to block users based on words/emojis in their username or display name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "blue-blocker",
-			"version": "0.3.9",
+			"version": "0.4.1",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@crxjs/vite-plugin": "^1.0.14",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,11 @@
 		"dev": "vite",
 		"build": "tsc && vite build",
 		"preview": "vite preview",
-		"fmt": "prettier --write **/*.{ts,json,css,scss,md}"
+		"fmt": "prettier --write **/*.{ts,json,css,scss,md}",
+		"version": "node -e \"const fs = require('fs').promises; fs.readFile('./src/manifest.ts','utf-8').then(oldManifest => oldManifest.replace(/(?:\\d+\\.){2}(?:\\d)(?:-[\\w\\d\\-\\.]*)?/, process.env.npm_package_version)).then(newManifest => fs.writeFile('./src/manifest.ts', newManifest, 'utf-8'))\" && git add ./src/manifest.ts ./package*.json && echo updated manifest, new version:"
+	},
+	"config": {
+		"git-tag-version": false
 	},
 	"engines": {
 		"node": ">=18.16.0"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,6 +36,7 @@ export const DefaultOptions: Config = {
 	skipFollowerCount: 1e6,
 	soupcanIntegration: false,
 	blockPromoted: false,
+	disallowedWords: [],
 
 	// this isn"t set, but is used
 	// TODO: when migrating to firefox manifest v3, check to see if sets can be stored yet
@@ -77,12 +78,14 @@ export const ReasonNftAvatar: number = 1;
 export const ReasonBusinessVerified: number = 2;
 export const ReasonTransphobia: number = 3;
 export const ReasonPromoted: number = 4;
+export const ReasonDisallowedWordsOrEmojis: number = 5;
 export const ReasonMap = {
 	[ReasonBlueVerified]: 'Twitter Blue verified',
 	[ReasonNftAvatar]: 'NFT avatar',
 	[ReasonBusinessVerified]: 'Twitter Business verified',
 	[ReasonTransphobia]: 'transphobia',
 	[ReasonPromoted]: 'promoting tweets',
+	[ReasonDisallowedWordsOrEmojis]: 'disallowed words or emojis',
 };
 
 export const LegacyVerifiedUrl: string =

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -17,6 +17,7 @@ interface Config {
 	soupcanIntegration: boolean;
 	blockPromoted: boolean;
 	blockForUse: boolean;
+	disallowedWords: string[];
 }
 
 interface BlueBlockerUser {

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -307,6 +307,17 @@
 					<span name="popup-timer-value"></span>
 				</div>
 			</div>
+			<div class="blockstrings">
+					<p>Block users with these words in their display name or username:</p>
+					<div class="blockstrings-option">
+						<textarea name="blockstrings-input" placeholder="Comma separated, Emojis allowed." id="blockstrings-input"></textarea>
+						<div class="option">
+							<p>This option may block non-blue users. <img src="/icon/warn.png" alt="⚠️" class="emoji" /></p>
+							<span name="blockstrings-input-status"></span>
+						</div>	
+					</div>
+					
+			</div>
 			<div class="safelist">
 				<p name="safelist-status">
 					safelist importing must be done on a separate page. click import to be

--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -258,7 +258,7 @@ input[type=number] {
 	width: 7em;
 	height: 1em;
 }
-input[type=number], select {
+input[type=number], select, textarea {
 	top: -0.1em;
 	position: relative;
 	display: inline-block;
@@ -273,13 +273,26 @@ input[type=number], select {
 	-o-transition: var(--transition) var(--fadetime);
 	transition: var(--transition) var(--fadetime);
 }
-input[type=number]:hover, select:hover {
+input[type=number]:hover, select:hover, textarea:hover {
 	color: var(--interact);
 	border-color: var(--borderhover);
 	box-shadow: 0 0 10px 3px var(--activeshadowcolor);
 }
 input[type=number]:focus, select:focus {
 	color: var(--textcolor);
+}
+
+textarea {
+	text-align: left;
+	min-height: 1.5em;
+	min-width: 20em;
+}
+
+.blockstrings-option {
+	margin-left: 1em;
+}
+.blockstrings-option > .option {
+	margin-top: .1em;
 }
 
 .gold-check {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -652,14 +652,11 @@ export async function BlockBlueVerified(user: BlueBlockerUser, config: Config) {
 			// this makes extra sure that emojis are always detected, regardless if they are attached to a word or another string of emojis.
 			// the 'i' makes the test case insensitive, which helps users not have to worry about typing the same word multiple times with different variations.
 			const disallowedWordsAndEmojis = new RegExp(config.disallowedWords.join('|'), 'i');
-			const wordsInUserName = user.legacy.name.toLocaleLowerCase().split(/\s+/);
-			for (const word of wordsInUserName) {
-				if (disallowedWordsAndEmojis.test(word)) {
-					queueBlockUser(user, String(user.rest_id), ReasonDisallowedWordsOrEmojis);
-					console.log(logstr, `${config.mute ? 'muted' : 'blocked'} ${formattedUserName} for having disallowed words/emojis in their username.`);
-					return;
-				}
-			}
+			const usernameToTest = (user.legacy.name).replace(/(?<= ) +/, '');
+			if (disallowedWordsAndEmojis.test(usernameToTest)) {
+				queueBlockUser(user, String(user.rest_id), ReasonDisallowedWordsOrEmojis);
+				console.log(logstr, `${config.mute ? 'muted' : 'blocked'} ${formattedUserName} for having disallowed words/emojis in their username.`);
+			  }
 		}
 
 		const legacyDbRejectMessage =

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -651,7 +651,7 @@ export async function BlockBlueVerified(user: BlueBlockerUser, config: Config) {
 		if (disallowedWordsWithoutEmptyStrings.length > 0){
 			// this makes extra sure that emojis are always detected, regardless if they are attached to a word or another string of emojis.
 			// the 'i' makes the test case insensitive, which helps users not have to worry about typing the same word multiple times with different variations.
-			const disallowedWordsAndEmojis = new RegExp(config.disallowedWords.join('|'), 'i');
+			const disallowedWordsAndEmojis = new RegExp(config.disallowedWords.map(word=>word.split('').join(' *')).join('(?= |$)|'), 'i');
 			const usernameToTest = (user.legacy.name).replace(/(?<= ) +/, '');
 			if (disallowedWordsAndEmojis.test(usernameToTest)) {
 				queueBlockUser(user, String(user.rest_id), ReasonDisallowedWordsOrEmojis);

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -19,6 +19,7 @@ import {
 	ReasonExternal,
 	IntegrationStateDisabled,
 	IntegrationStateReceiveOnly,
+	ReasonDisallowedWordsOrEmojis,
 } from './constants';
 
 import {
@@ -643,6 +644,22 @@ export async function BlockBlueVerified(user: BlueBlockerUser, config: Config) {
 		) {
 			console.debug(logstr, `skipped user ${formattedUserName} because they follow you.`);
 			return;
+		}
+
+		// Step 0: Check for disallowed words or emojis in usernames.
+		const disallowedWordsWithoutEmptyStrings = config.disallowedWords.filter(word => word !== '');
+		if (disallowedWordsWithoutEmptyStrings.length > 0){
+			// this makes extra sure that emojis are always detected, regardless if they are attached to a word or another string of emojis.
+			// the 'i' makes the test case insensitive, which helps users not have to worry about typing the same word multiple times with different variations.
+			const disallowedWordsAndEmojis = new RegExp(config.disallowedWords.join('|'), 'i');
+			const wordsInUserName = user.legacy.name.toLocaleLowerCase().split(/\s+/);
+			for (const word of wordsInUserName) {
+				if (disallowedWordsAndEmojis.test(word)) {
+					queueBlockUser(user, String(user.rest_id), ReasonDisallowedWordsOrEmojis);
+					console.log(logstr, `${config.mute ? 'muted' : 'blocked'} ${formattedUserName} for having disallowed words/emojis in their username.`);
+					return;
+				}
+			}
 		}
 
 		const legacyDbRejectMessage =

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -651,7 +651,7 @@ export async function BlockBlueVerified(user: BlueBlockerUser, config: Config) {
 		if (disallowedWordsWithoutEmptyStrings.length > 0){
 			// this makes extra sure that emojis are always detected, regardless if they are attached to a word or another string of emojis.
 			// the 'i' makes the test case insensitive, which helps users not have to worry about typing the same word multiple times with different variations.
-			const disallowedWordsAndEmojis = new RegExp(config.disallowedWords.map(word=>word.split('').join(' *')).join('(?= |$)|'), 'i');
+			const disallowedWordsAndEmojis = new RegExp(`${config.disallowedWords.map(word=>word.split('').join(' *')).join('(?= |$)|')}(?= |$)`, 'i');
 			const usernameToTest = (user.legacy.name).replace(/(?<= ) +/, '');
 			if (disallowedWordsAndEmojis.test(usernameToTest)) {
 				queueBlockUser(user, String(user.rest_id), ReasonDisallowedWordsOrEmojis);


### PR DESCRIPTION
closes #114

Allows blue blocker users to specifically block Twitter users with their own list of words/emojis. 

This is intended to block users with inflammatory or offensive names, but can also be used to block users who you might not vibe with, simply by defining a few keywords or emojis that can be seen on usernames of people you don't want to see on your timeline or replies.

For example, if you don't want to see users with the glitched 🏳️‍🌈” ⃠, emojis, or if you don't want to see🔞due to it being associated with NSFW accounts which is something you don't want to interact with. Just add it to the list in the extension's settings.

![image](https://github.com/kheina-com/Blue-Blocker/assets/34368774/8abd4d1f-bd42-4505-91b6-26ee2b8e299a)


## Notes:

- I was unable to test on firefox due to it not being able to load the manifest file for some reason.
- the safelist buttons disappeared and I have no idea how to make them come back.

## Changelog
- [FEAT] Added the ability to block users based on disallowed words/emojis in usernames.

## Deployment Checklist
1. [ ] merge all pull requests to llb
2. [ ] ensure `src/manifest.ts` and `package.json` have the correct version number
3. [ ] use makefile to generate zips (`make chrome`, `make firefox`)
    - [X] chrome should be tested with `npm run build`
    - [ ] test firefox locally using zip
4. [ ] merge llb to main
5. [ ] upload zips from `3` to chrome webstore and firefox addons
