### PR TITLE
[feat] adds the option to skip blue checkmark users

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,6 +28,7 @@ export const DefaultOptions: Config = {
 	mute: false,
 	blockFollowing: false,
 	blockFollowers: false,
+	skipBlueCheckmark: false,
 	skipVerified: true,
 	skipAffiliated: true,
 	skip1Mplus: true,

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -7,6 +7,7 @@ interface Config {
 	mute: boolean;
 	blockFollowing: boolean;
 	blockFollowers: boolean;
+	skipBlueCheckmark : boolean;
 	skipVerified: boolean;
 	skipAffiliated: boolean;
 	skip1Mplus: boolean;

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -35,6 +35,7 @@
 		<input type="checkbox" id="block-following" />
 		<input type="checkbox" id="block-followers" />
 		<input type="checkbox" id="skip-verified" />
+		<input type="checkbox" id="skip-checkmark" />
 		<input type="checkbox" id="skip-affiliated" />
 		<input type="checkbox" id="skip-1mplus" />
 		<input type="checkbox" id="block-promoted-tweets" />
@@ -159,6 +160,15 @@
 					<p>block people who follow me</p>
 				</label>
 				<span name="block-followers-status"></span>
+			</div>
+			<div class="option">
+				<label for="skip-checkmark" name="skip-checkmark">
+					<div class="checkmark">
+						<div></div>
+					</div>
+					<p>skip blue checkmark users</p>
+				</label>
+				<span name="skip-checkmark-status"></span>
 			</div>
 			<div class="option">
 				<label for="skip-verified" name="skip-verified">

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -219,6 +219,7 @@ document.addEventListener('DOMContentLoaded', () => {
 	const skip1Mplus = document.getElementById('skip-1mplus') as HTMLInputElement;
 	const blockPromoted = document.getElementById('block-promoted-tweets') as HTMLInputElement;
 	const blockForUse = document.getElementById('block-for-use') as HTMLInputElement;
+	const skipCheckmark = document.getElementById('skip-checkmark') as HTMLInputElement;
 	const soupcanIntegration = document.getElementById('soupcan-integration') as HTMLInputElement;
 
 	api.storage.sync.get(DefaultOptions).then((_config) => {
@@ -244,7 +245,8 @@ document.addEventListener('DOMContentLoaded', () => {
 			optionName: 'skip-follower-count-option',
 		});
 		checkHandler(blockPromoted, config, 'blockPromoted');
-		checkHandler(blockForUse, config, 'blockForUse')
+		checkHandler(blockForUse, config, 'blockForUse');
+		checkHandler(skipCheckmark, config, 'skipBlueCheckmark');
 		checkHandler(soupcanIntegration, config, 'soupcanIntegration', {
 			optionName: '', // integration isn't controlled by the toggle, so unset
 		});
@@ -330,7 +332,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			blockedUsersCount.textContent = commafy(items.BlockCounter.newValue);
 			QueueLength().then(count => {
 				blockedUserQueueLength.textContent = commafy(count);
-			});		
+			});
 		}
 		if (items.hasOwnProperty('BlockQueue')) {
 			blockedUserQueueLength.textContent = commafy(items.BlockQueue.newValue.length);

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -648,7 +648,7 @@ export async function BlockBlueVerified(user: BlueBlockerUser, config: Config) {
 		const legacyDbRejectMessage =
 			'could not access the legacy verified database, skip legacy has been disabled.';
 		// step 1: is user verified
-		if (user.is_blue_verified || hasBlockableVerifiedTypes || hasBlockableAffiliateLabels) {
+		if ((config.skipBlueCheckmark == false && user.is_blue_verified) || hasBlockableVerifiedTypes || hasBlockableAffiliateLabels) {
 			if (
 				// skip checking for legacy if the config says to
 				// if the option is disabled, non-legacy verified blue users will still get caught by the last else block


### PR DESCRIPTION
closes #166

Adds the ability to skip over blue checkmark users because some users might want to only use this extension to block ads or offensive users, but not block every blue checkmark user out there.

## Changelog
```txt
Summary
	1. document grouping follow 'SemVer2.0' protocol
	2. use 'PATCH' as a minimum granularity
	3. use concise descriptions
	4. type: feat \ fix \ update \ perf \ remove \ docs \ chore
	5. version timestamp follow the yyyy.MM.dd format
```

## Deployment Checklist
1. [ ] merge all pull requests to llb
2. [ ] ensure `src/manifest.ts` and `package.json` have the correct version number
3. [ ] use makefile to generate zips (`make chrome`, `make firefox`)
    - [X] chrome should be tested with `npm run build`
    - [ ] test firefox locally using zip
4. [ ] merge llb to main
5. [ ] upload zips from `3` to chrome webstore and firefox addons
