### PR TITLE
[fix] Add x.com to permissions

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -18,7 +18,7 @@ export default defineManifest({
 	},
 	content_scripts: [
 		{
-			matches: ["*://*.twitter.com/*", "*://twitter.com/*"],
+			matches: ["*://*.twitter.com/*", "*://twitter.com/*", "*://*.x.com/*", "*://x.com/*"],
 			js: ["src/content/index.ts"],
 		},
 	],
@@ -30,7 +30,7 @@ export default defineManifest({
 				"src/injected/*",
 				"icon/*",
 			],
-			matches: ["*://*.twitter.com/*", "*://twitter.com/*"],
+			matches: ["*://*.twitter.com/*", "*://twitter.com/*", "*://*.x.com/*", "*://x.com/*"],
 		},
 	],
 });


### PR DESCRIPTION
Should fix #280, and keep the extension working after Musk fully transitions to using the stupid domain he overpaid for 30 years ago.

Note: this PR is against the 0.4.2 LLB, changes will be merged into main by #267