### PR TITLE
[Feat] get users from tweet like pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blue-blocker",
-	"version": "0.4.2",
+	"version": "0.4.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blue-blocker",
-			"version": "0.4.2",
+			"version": "0.4.3",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@crxjs/vite-plugin": "^1.0.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blue-blocker",
-	"version": "0.4.2",
+	"version": "0.4.3",
 	"author": "DanielleMiu",
 	"description": "Blocks all Twitter Blue verified users on twitter.com",
 	"type": "module",

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -82,6 +82,7 @@ document.addEventListener('blue-blocker-event', function (e: CustomEvent<BlueBlo
 				case 'UserCreatorSubscriptions':
 				case 'FollowersYouKnow':
 				case 'BlueVerifiedFollowers':
+				case 'Favoriters':
 					return HandleInstructionsResponse(e, parsed_body, compileConfig(config));
 				case 'timeline/home.json':
 				case 'search/adaptive.json':

--- a/src/injected/inject.ts
+++ b/src/injected/inject.ts
@@ -3,7 +3,7 @@
 (function (xhr) {
 	// TODO: find a way to make this cleaner
 	const RequestRegex =
-		/^https?:\/\/(?:\w+\.)?(?:twitter|x)\.com\/[\w\/\.\-\_\=]+\/(HomeLatestTimeline|HomeTimeline|Followers|Following|SearchTimeline|UserTweets|UserCreatorSubscriptions|FollowersYouKnow|BlueVerifiedFollowers|timeline\/home\.json|TweetDetail|search\/typeahead\.json|search\/adaptive\.json|blocks\/destroy\.json|mutes\/users\/destroy\.json)(?:$|\?)/;
+		/^https?:\/\/(?:\w+\.)?(?:twitter|x)\.com\/[\w\/\.\-\_\=]+\/(HomeLatestTimeline|HomeTimeline|Followers|Following|SearchTimeline|UserTweets|Favoriters|UserCreatorSubscriptions|FollowersYouKnow|BlueVerifiedFollowers|timeline\/home\.json|TweetDetail|search\/typeahead\.json|search\/adaptive\.json|blocks\/destroy\.json|mutes\/users\/destroy\.json)(?:$|\?)/;
 
 	let XHR = <BlueBlockerXLMRequest>XMLHttpRequest.prototype;
 	let open = XHR.open;

--- a/src/injected/inject.ts
+++ b/src/injected/inject.ts
@@ -3,7 +3,7 @@
 (function (xhr) {
 	// TODO: find a way to make this cleaner
 	const RequestRegex =
-		/^https?:\/\/(?:\w+\.)?(?:twitter|x)\.com\/[\w\/\.\-\_\=]+\/(HomeLatestTimeline|HomeTimeline|Followers|Following|SearchTimeline|UserTweets|UserCreatorSubscriptions|FollowersYouKnow|BlueVerifiedFollowers|SearchTimeline|timeline\/home\.json|TweetDetail|search\/typeahead\.json|search\/adaptive\.json|blocks\/destroy\.json|mutes\/users\/destroy\.json)(?:$|\?)/;
+		/^https?:\/\/(?:\w+\.)?(?:twitter|x)\.com\/[\w\/\.\-\_\=]+\/(HomeLatestTimeline|HomeTimeline|Followers|Following|SearchTimeline|UserTweets|UserCreatorSubscriptions|FollowersYouKnow|BlueVerifiedFollowers|timeline\/home\.json|TweetDetail|search\/typeahead\.json|search\/adaptive\.json|blocks\/destroy\.json|mutes\/users\/destroy\.json)(?:$|\?)/;
 
 	let XHR = <BlueBlockerXLMRequest>XMLHttpRequest.prototype;
 	let open = XHR.open;

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -3,7 +3,7 @@ import { defineManifest } from '@crxjs/vite-plugin';
 export default defineManifest({
 	name: 'Blue Blocker',
 	description: 'Blocks all Twitter Blue verified users on twitter.com',
-	version: '0.4.2',
+	version: '0.4.3',
 	manifest_version: 3,
 	icons: {
 		'128': 'icon/icon-128.png',

--- a/src/parsers/instructions.ts
+++ b/src/parsers/instructions.ts
@@ -11,6 +11,7 @@ const InstructionsPaths: { [key: string]: string[] } = {
 	HomeLatestTimeline: ['data', 'home', 'home_timeline_urt', 'instructions'],
 	HomeTimeline: ['data', 'home', 'home_timeline_urt', 'instructions'],
 	SearchTimeline: ['data', 'search_by_raw_query', 'search_timeline', 'timeline', 'instructions'],
+	Favoriters: ['data', 'favoriters_timeline', 'timeline', 'instructions'],
 	UserTweets: ['data', 'user', 'result', 'timeline_v2', 'timeline', 'instructions'],
 	Followers: ['data', 'user', 'result', 'timeline', 'timeline', 'instructions'],
 	Following: ['data', 'user', 'result', 'timeline', 'timeline', 'instructions'],

--- a/src/parsers/instructions.ts
+++ b/src/parsers/instructions.ts
@@ -34,7 +34,11 @@ const IgnoreTweetTypes = new Set(['TimelineTimelineCursor']);
 const PromotedStrings = new Set(['suggest_promoted', 'Promoted', 'promoted']);
 
 function handleUserObject(obj: any, config: CompiledConfig, from_blue: boolean) {
-	let userObj = obj.user_results.result;
+	let userObj = obj.user_results?.result;
+	if (!userObj) {
+		console.log(logstr, 'empty user result');
+		return;
+	}
 
 	if (userObj.__typename === 'UserUnavailable') {
 		console.log(logstr, 'user is unavailable', userObj);


### PR DESCRIPTION
Pretty small and simple. To see the feature in action go to a page like 
[the likes on an Elon tweet](https://x.com/elonmusk/status/1793467069922725951/likes) and watch your queue go up!

## Deployment Checklist

1. [x] ensure `src/manifest.ts` and `package.json` have the correct version number
2. [ ] use makefile to generate zips (`make chrome`, `make firefox`)
    - [x] chrome should be tested with `npm run build`
    - [ ] test firefox locally using zip
