### PR TITLE
Create a more granular version of CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,24 @@
-*		@kheina @jaredkotoff @MrAwesome @cooljeanius @rougetimelord
+.github/workflows/codeql.yml @cooljeanius
+.github/workflows/njsscan.yml @cooljeanius
+.github/workflows/release.yml @kheina @rougetimelord
+.github/CODEOWNERS @kheina @cooljeanius
+.github/dependabot.yml @cooljeanius
+.github/pull_request_template.md @kheina
+assets/* @kheina @jaredkotoff
+public/icon/* @kheina @jaredkotoff
+src/* @kheina @jaredkotoff @cooljeanius @rougetimelord
+.editorconfig @kheina @jaredkotoff
+.gitignore @kheina @jaredkotoff @cooljeanius
+.npmignore @kheina @jaredkotoff @cooljeanius
+.nvmrc @kheina @jaredkotoff
+.prettierignore @kheina @jaredkotoff
+.prettierrc @kheina @jaredkotoff
+CHANGELOG.md @kheina @rougetimelord
+LICENSE @kheina
+makefile @kheina @cooljeanius
+package-lock.json @kheina @jaredkotoff @cooljeanius @rougetimelord
+package.json @kheina @jaredkotoff @cooljeanius @rougetimelord
+readme.md @kheina @jaredkotoff @cooljeanius @rougetimelord
+tsconfig.json @kheina @jaredkotoff
+tsconfig.node.json @kheina @jaredkotoff
+vite.config.ts @kheina @jaredkotoff @cooljeanius @rougetimelord

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,4 +21,4 @@ package.json @kheina @jaredcat @cooljeanius @rougetimelord
 readme.md @kheina @jaredcat @cooljeanius @rougetimelord
 tsconfig.json @kheina @jaredcat
 tsconfig.node.json @kheina @jaredcat
-vite.config.ts @kheina @jaredcat @cooljeanius @rougetimelord
+vite.config.ts @kheina @jaredcat @cooljeanius

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,8 @@
 .github/CODEOWNERS @kheina @cooljeanius
 .github/dependabot.yml @cooljeanius
 .github/pull_request_template.md @kheina
-assets/* @kheina @jaredcat
-public/icon/* @kheina @jaredcat
+assets/* @kheina
+public/icon/* @kheina
 src/* @kheina @jaredcat @cooljeanius @rougetimelord
 .editorconfig @kheina @jaredcat
 .gitignore @kheina @jaredcat @cooljeanius
@@ -16,7 +16,7 @@ src/* @kheina @jaredcat @cooljeanius @rougetimelord
 CHANGELOG.md @kheina @rougetimelord
 LICENSE @kheina
 makefile @kheina @cooljeanius
-package-lock.json @kheina @jaredcat @cooljeanius @rougetimelord
+package-lock.json @kheina @cooljeanius @rougetimelord
 package.json @kheina @jaredcat @cooljeanius @rougetimelord
 readme.md @kheina @jaredcat @cooljeanius @rougetimelord
 tsconfig.json @kheina @jaredcat

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,21 +4,21 @@
 .github/CODEOWNERS @kheina @cooljeanius
 .github/dependabot.yml @cooljeanius
 .github/pull_request_template.md @kheina
-assets/* @kheina @jaredkotoff
-public/icon/* @kheina @jaredkotoff
-src/* @kheina @jaredkotoff @cooljeanius @rougetimelord
-.editorconfig @kheina @jaredkotoff
-.gitignore @kheina @jaredkotoff @cooljeanius
-.npmignore @kheina @jaredkotoff @cooljeanius
-.nvmrc @kheina @jaredkotoff
-.prettierignore @kheina @jaredkotoff
-.prettierrc @kheina @jaredkotoff
+assets/* @kheina @jaredcat
+public/icon/* @kheina @jaredcat
+src/* @kheina @jaredcat @cooljeanius @rougetimelord
+.editorconfig @kheina @jaredcat
+.gitignore @kheina @jaredcat @cooljeanius
+.npmignore @kheina @jaredcat @cooljeanius
+.nvmrc @kheina @jaredcat
+.prettierignore @kheina @jaredcat
+.prettierrc @kheina @jaredcat
 CHANGELOG.md @kheina @rougetimelord
 LICENSE @kheina
 makefile @kheina @cooljeanius
-package-lock.json @kheina @jaredkotoff @cooljeanius @rougetimelord
-package.json @kheina @jaredkotoff @cooljeanius @rougetimelord
-readme.md @kheina @jaredkotoff @cooljeanius @rougetimelord
-tsconfig.json @kheina @jaredkotoff
-tsconfig.node.json @kheina @jaredkotoff
-vite.config.ts @kheina @jaredkotoff @cooljeanius @rougetimelord
+package-lock.json @kheina @jaredcat @cooljeanius @rougetimelord
+package.json @kheina @jaredcat @cooljeanius @rougetimelord
+readme.md @kheina @jaredcat @cooljeanius @rougetimelord
+tsconfig.json @kheina @jaredcat
+tsconfig.node.json @kheina @jaredcat
+vite.config.ts @kheina @jaredcat @cooljeanius @rougetimelord


### PR DESCRIPTION
This should help keep review requests be more precisely targeted to relevant reviewers.
I made the decisions for who to assign to which files based on git history and blame, as well as in my personal case, just selecting files I'd be comfortable editing. Note that I didn't dig in too deep to the history in `src/*`, so it's possible there could be additional changes to make there. Also, I had previously added more names than this, but removed people who never responded to my invitations to collaborate on my fork.
