### PR TITLE
Rewrite EscapeHTML func to be safer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blue-blocker",
-	"version": "0.4.2",
+	"version": "0.4.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blue-blocker",
-			"version": "0.4.2",
+			"version": "0.4.3",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@crxjs/vite-plugin": "^1.0.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blue-blocker",
-	"version": "0.4.2",
+	"version": "0.4.3",
 	"author": "DanielleMiu",
 	"description": "Blocks all Twitter Blue verified users on twitter.com",
 	"type": "module",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -3,7 +3,7 @@ import { defineManifest } from '@crxjs/vite-plugin';
 export default defineManifest({
 	name: 'Blue Blocker',
 	description: 'Blocks all Twitter Blue verified users on twitter.com',
-	version: '0.4.2',
+	version: '0.4.3',
 	manifest_version: 3,
 	icons: {
 		'128': 'icon/icon-128.png',

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -200,7 +200,7 @@ export function EscapeHtml(unsafe: string): string {
 	 */
 	const partiallySafe = element.innerHTML;
 	// Step 4, replace single and double quotes with entities so that the string can be added to attributes safely
-	const safe = partiallySafe.replace(/'/g, '&#039;').replace(/"/g, '&quot;').replace(/&/, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+	const safe = partiallySafe.replace(/'/g, '&#039;').replace(/"/g, '&quot;').replace(/&(?![#\w]{2,};)/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
 	return safe;
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -187,8 +187,22 @@ export function escapeRegExp(text: string) {
 	return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-export function EscapeHtml(text: string): string {
-	return new Option(text).innerHTML;
+export function EscapeHtml(unsafe: string): string {
+	// Step 1, create an element
+	const element = document.createElement('div');
+	// Step 2, safely add text to the element
+	element.textContent = unsafe;
+	/**
+	 * Step 3, let the browser handle turning most HTML characters into entities
+	 * Using innerText here returns a string that doesn't have HTML entities, so we use innerHTML to get entities.
+	 *
+	 * If a browser engine cannot do this, it means that setting Element.textContent is unsafe...
+	 */
+	const partiallySafe = element.innerHTML;
+	// Step 4, replace single and double quotes with entities so that the string can be added to attributes safely
+	const safe = partiallySafe.replace(/'/g, '&#039;').replace(/"/g, '&quot;');
+
+	return safe;
 }
 
 export async function QueuePop(): Promise<BlockUser | null> {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -200,7 +200,7 @@ export function EscapeHtml(unsafe: string): string {
 	 */
 	const partiallySafe = element.innerHTML;
 	// Step 4, replace single and double quotes with entities so that the string can be added to attributes safely
-	const safe = partiallySafe.replace(/'/g, '&#039;').replace(/"/g, '&quot;');
+	const safe = partiallySafe.replace(/'/g, '&#039;').replace(/"/g, '&quot;').replace(/&/, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
 	return safe;
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -193,14 +193,14 @@ export function EscapeHtml(unsafe: string): string {
 	// Step 2, safely add text to the element
 	element.textContent = unsafe;
 	/**
-	 * Step 3, let the browser handle turning most HTML characters into entities
-	 * Using innerText here returns a string that doesn't have HTML entities, so we use innerHTML to get entities.
+	 * Step 3, let the browser handle turning "<", ">", and "&" into entities
+	 * Using innerText here returns a string that doesn't use HTML entities, so we use innerHTML to get entities.
 	 *
 	 * If a browser engine cannot do this, it means that setting Element.textContent is unsafe...
 	 */
 	const partiallySafe = element.innerHTML;
 	// Step 4, replace single and double quotes with entities so that the string can be added to attributes safely
-	const safe = partiallySafe.replace(/'/g, '&#039;').replace(/"/g, '&quot;').replace(/&(?![#\w]{2,};)/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+	const safe = partiallySafe.replace(/'/g, '&#039;').replace(/"/g, '&quot;');
 
 	return safe;
 }


### PR DESCRIPTION
Mozilla kinda had a point, we set the href attribute of an anchor tag to the escaped string. Therefore, we need to make sure to escape single and double quotes.

Definitely could be minimized slightly, but I want to make sure the reviewer understands what's happening fully. This is safe, it destroys tags, and does not allow you to escape the confines of an attribute in order to add tag level event handlers.

See #294 for more details.

1. [x] ensure `src/manifest.ts` and `package.json` have the correct version number
2. [x] use makefile to generate zips (`make chrome`, `make firefox`)
    - [x] chrome should be tested with `npm run build`
    - [ ] test firefox locally using zip
3. [ ] merge to main
