### PR TITLE
[feat] Skip people retweeted by people you follow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blue-blocker",
-	"version": "0.4.11",
+	"version": "0.4.12",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blue-blocker",
-			"version": "0.4.11",
+			"version": "0.4.12",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@crxjs/vite-plugin": "=2.0.0-beta.26",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blue-blocker",
-	"version": "0.4.11",
+	"version": "0.4.12",
 	"author": "DanielleMiu",
 	"description": "Blocks all Twitter Blue verified users on twitter.com",
 	"type": "module",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,6 +24,7 @@ export const DefaultOptions: Config = {
 	mute: false,
 	blockFollowing: false,
 	blockFollowers: false,
+	skipFollowingQrts: false,
 	skipBlueCheckmark: false,
 	skipVerified: true,
 	skipAffiliated: true,

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -16,6 +16,7 @@ function compileConfig(config: Config): CompiledConfig {
 		mute: config.mute,
 		blockFollowing: config.blockFollowing,
 		blockFollowers: config.blockFollowers,
+		skipFollowingQrts: config.skipFollowingQrts,
 		skipBlueCheckmark: config.skipBlueCheckmark,
 		skipVerified: config.skipVerified,
 		skipAffiliated: config.skipAffiliated,

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -41,7 +41,7 @@ function compileConfig(config: Config): CompiledConfig {
 							)
 							.join('|'),
 						'i',
-				  ),
+					),
 	} as CompiledConfig;
 }
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -7,6 +7,7 @@ interface Config {
 	mute: boolean;
 	blockFollowing: boolean;
 	blockFollowers: boolean;
+	skipFollowingQrts: boolean;
 	skipBlueCheckmark: boolean;
 	skipVerified: boolean;
 	skipAffiliated: boolean;
@@ -29,6 +30,7 @@ interface CompiledConfig {
 	mute: boolean;
 	blockFollowing: boolean;
 	blockFollowers: boolean;
+	skipFollowingQrts: boolean;
 	skipBlueCheckmark: boolean;
 	skipVerified: boolean;
 	skipAffiliated: boolean;

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -3,7 +3,7 @@ import { defineManifest } from '@crxjs/vite-plugin';
 export default defineManifest({
 	name: 'Blue Blocker',
 	description: 'Blocks all Twitter Blue verified users on twitter.com',
-	version: '0.4.11',
+	version: '0.4.12',
 	manifest_version: 3,
 	icons: {
 		'128': 'icon/icon-128.png',

--- a/src/parsers/instructions.ts
+++ b/src/parsers/instructions.ts
@@ -109,8 +109,12 @@ export function ParseTimelineTweet(tweet: any, config: CompiledConfig) {
 	}
 
 	try {
+		if (config.skipFollowingQrts && tweet?.itemContent?.tweet_results?.result?.core?.user_results?.result?.legacy?.following && (tweet?.itemContent?.tweet_results?.result?.legacy?.is_quote_status || tweet?.tweet_results?.result?.legacy?.retweeted_status_result)) {
+			const skippedUser = tweet?.itemContent?.tweet_results?.result?.legacy?.retweeted_status_result?.result?.core?.user_results?.result || tweet?.itemContent?.tweet_results?.result?.quoted_status_result?.result?.core?.user_results?.result;
+			console.log(logstr, `skipping ${skippedUser.legacy.name} (@${skippedUser.legacy.screen_name}) because they got retweeted by someone you follow`)
+		}
 		// Handle retweets and quoted tweets (check the retweeted user, too)
-		if (tweet?.itemContent?.tweet_results?.result?.quoted_status_result?.result) {
+		else if (tweet?.itemContent?.tweet_results?.result?.quoted_status_result?.result) {
 			handleTweetObject(
 				tweet.itemContent.tweet_results.result.quoted_status_result.result,
 				config,

--- a/src/parsers/instructions.ts
+++ b/src/parsers/instructions.ts
@@ -109,9 +109,22 @@ export function ParseTimelineTweet(tweet: any, config: CompiledConfig) {
 	}
 
 	try {
-		if (config.skipFollowingQrts && tweet?.itemContent?.tweet_results?.result?.core?.user_results?.result?.legacy?.following && (tweet?.itemContent?.tweet_results?.result?.legacy?.is_quote_status || tweet?.tweet_results?.result?.legacy?.retweeted_status_result)) {
-			const skippedUser = tweet?.itemContent?.tweet_results?.result?.legacy?.retweeted_status_result?.result?.core?.user_results?.result || tweet?.itemContent?.tweet_results?.result?.quoted_status_result?.result?.core?.user_results?.result;
-			console.log(logstr, `skipping ${skippedUser.legacy.name} (@${skippedUser.legacy.screen_name}) because they got retweeted by someone you follow`)
+		if (
+			config.skipFollowingQrts &&
+			tweet?.itemContent?.tweet_results?.result?.core?.user_results?.result?.legacy
+				?.following &&
+			(tweet?.itemContent?.tweet_results?.result?.legacy?.is_quote_status ||
+				tweet?.tweet_results?.result?.legacy?.retweeted_status_result)
+		) {
+			const skippedUser =
+				tweet?.itemContent?.tweet_results?.result?.legacy?.retweeted_status_result?.result
+					?.core?.user_results?.result ||
+				tweet?.itemContent?.tweet_results?.result?.quoted_status_result?.result?.core
+					?.user_results?.result;
+			console.log(
+				logstr,
+				`skipping ${skippedUser.legacy.name} (@${skippedUser.legacy.screen_name}) because they got retweeted by someone you follow`,
+			);
 		}
 		// Handle retweets and quoted tweets (check the retweeted user, too)
 		else if (tweet?.itemContent?.tweet_results?.result?.quoted_status_result?.result) {

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -74,6 +74,7 @@
 		<input type="checkbox" id="block-promoted-tweets" />
 		<input type="checkbox" id="block-for-use" />
 		<input type="checkbox" id="blockstrings" />
+		<input type="checkbox" id="skip-following-qrts">
 		<div class="tab" id="general">
 			<div class="option">
 				<label for="suspend-block-collection" name="suspend-block-collection">
@@ -119,6 +120,15 @@
 					<p>block people who follow me</p>
 				</label>
 				<span name="block-followers-status"></span>
+			</div>
+			<div class="option">
+				<label for="skip-following-qrts" name="skip-following-qrts">
+					<div class="checkmark">
+						<div></div>
+					</div>
+					<p>skip blocking retweets from people I follow</p>
+				</label>
+				<span name="skip-following-qrts-status"></span>
 			</div>
 			<div>
 				<div class="option">

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -288,6 +288,7 @@ document.addEventListener('DOMContentLoaded', () => {
 	const muteInsteadOfBlock = document.getElementById('mute-instead-of-block') as HTMLInputElement;
 	const blockFollowing = document.getElementById('block-following') as HTMLInputElement;
 	const blockFollowers = document.getElementById('block-followers') as HTMLInputElement;
+	const skipFollowingQrts = document.getElementById('skip-following-qrts') as HTMLInputElement;
 	const skipVerified = document.getElementById('skip-verified') as HTMLInputElement;
 	const skipAffiliated = document.getElementById('skip-affiliated') as HTMLInputElement;
 	const skip1Mplus = document.getElementById('skip-1mplus') as HTMLInputElement;
@@ -313,6 +314,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		checkHandler(muteInsteadOfBlock, config, 'mute');
 		checkHandler(blockFollowing, config, 'blockFollowing');
 		checkHandler(blockFollowers, config, 'blockFollowers');
+		checkHandler(skipFollowingQrts, config, 'skipFollowingQrts');
 		checkHandler(skipVerified, config, 'skipVerified');
 		checkHandler(skipAffiliated, config, 'skipAffiliated');
 		checkHandler(skip1Mplus, config, 'skip1Mplus', {


### PR DESCRIPTION
Pretty simple little feature to add. Closes #71.

Not super sure about what tab to put the option into, I think general is the best fit?

It should also probably be noted that for retweets, if you click on the tweet you get the page for the retweeted tweet directly which means you don't get information about who retweeted the status anymore. In other words, clicking on a tweet will make the check for retweeting by someone you follow to break and the tweet author will be blocked. 
Not super sure how to fix that issue though. One option is to add the retweeted user to the safelist, but I think that would override user intent in using the safelist.