### PR TITLE
Fix a bug where Firefox users were not getting the consent flow if they updated from non-listed versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blue-blocker",
-	"version": "0.4.13",
+	"version": "0.4.14",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blue-blocker",
-			"version": "0.4.13",
+			"version": "0.4.14",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@crxjs/vite-plugin": "=2.0.0-beta.26",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blue-blocker",
-	"version": "0.4.13",
+	"version": "0.4.14",
 	"author": "DanielleMiu",
 	"description": "Blocks all Twitter Blue verified users on twitter.com",
 	"type": "module",

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -125,14 +125,29 @@ api.runtime.onStartup.addListener(() => {
 	}
 })
 
-const consentRequiredVersions = ['0.3.5']
+const minConsentVersion = '0.4.14';
+
+function isBelowMinVer(newVersion: string, minVersion: string) {
+	const [newMajor, newMinor, newPatch] = String(newVersion).split('.').map(Number);
+	const [minMajor, minMinor, minPatch] = String(minVersion).split('.').map(Number);
+
+	if (newMajor !== minMajor) {
+		return newMajor < minMajor;
+	}
+
+	if (newMinor !== minMinor) {
+		return newMinor < minMinor;
+	}
+
+	return newPatch < minPatch;
+}
 
 api.runtime.onInstalled.addListener( ({reason, previousVersion}) => {
 	try {
 		/** @ts-ignore I hate that I have to use FF specific APIs to detect FF :)))*/
 		api.runtime?.getBrowserInfo().then(info => {
 			if (info.name == 'Firefox') {
-				if(reason == 'install' || (reason == 'update' && consentRequiredVersions.includes(previousVersion as string))) {
+				if(reason == 'install' || (reason == 'update' && isBelowMinVer(previousVersion as string, minConsentVersion))) {
 					registerConsentScript();
 					const url = api.runtime.getURL('src/pages/consent/index.html');
 					api.tabs.create({url})

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -109,7 +109,7 @@ api.runtime.onStartup.addListener(() => {
 		// @ts-ignore
 		api.runtime?.getBrowserInfo().then(info => {
 			if(info.name == 'Firefox') {
-				api.storage.local.get("canLoad").then( val => {
+				api.storage.local.get({"canLoad": false}).then( val => {
 					if (!val) {
 						registerConsentScript();
 					}
@@ -117,6 +117,10 @@ api.runtime.onStartup.addListener(() => {
 						registerContentScript();
 					}
 				});
+			}
+			else {
+				// In a FF based browser, that isn't FF
+				registerConsentScript();
 			}
 		})
 	}
@@ -152,6 +156,10 @@ api.runtime.onInstalled.addListener( ({reason, previousVersion}) => {
 					const url = api.runtime.getURL('src/pages/consent/index.html');
 					api.tabs.create({url})
 				}
+			}
+			else {
+				// In a FF based browser, that isn't FF
+				registerConsentScript();
 			}
 		})
 	}

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -3,7 +3,7 @@ import { defineManifest } from '@crxjs/vite-plugin';
 export default defineManifest({
 	name: 'Blue Blocker',
 	description: 'Blocks all Twitter Blue verified users on twitter.com',
-	version: '0.4.13',
+	version: '0.4.14',
 	manifest_version: 3,
 	icons: {
 		'128': 'icon/icon-128.png',

--- a/src/pages/consent/index.html
+++ b/src/pages/consent/index.html
@@ -33,6 +33,7 @@
             <p>All data that Blue Blocker collects, stores, uses, and transmits is mandatory for the function of the extension Because the collection, storage, usage, and transmission of personal data is necessary for the function of this extension, refusing will cause the extension to be uninstalled</p>
             <br>
             <p>To read the full privacy policy visit the <a href="https://addons.mozilla.org/en-US/firefox/addon/blue-blocker/privacy/" target="_blank" rel="noopener noreferrer">Firefox addons page</a></p>
+            <p>You might be shown this screen again in the future; for example if there is an update in Firefox's policies.</p>
             <br>
             <p>Having read the above disclosure, do you consent to Blue Blocker collecting, storing, using, and transmitting your personal data?</p>
             <div class="inputs">


### PR DESCRIPTION
This should fix #383, and also includes some little changes that should make the flow work better for users on Firefox based browsers that are not Firefox. I also added some wording to the consent page about the popup possibly appearing again