### PR TITLE
[fix] fix an issue where consent state was ignored on non-mainline firefox releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blue-blocker",
-	"version": "0.4.14",
+	"version": "0.4.15",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blue-blocker",
-			"version": "0.4.14",
+			"version": "0.4.15",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@crxjs/vite-plugin": "=2.0.0-beta.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blue-blocker",
-	"version": "0.4.14",
+	"version": "0.4.15",
 	"author": "DanielleMiu",
 	"description": "Blocks all Twitter Blue verified users on twitter.com",
 	"type": "module",

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -120,7 +120,7 @@ api.runtime.onStartup.addListener(() => {
 			}
 			else {
 				// In a FF based browser, that isn't FF
-				registerConsentScript();
+				registerContentScript();
 			}
 		})
 	}

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -108,7 +108,7 @@ api.runtime.onStartup.addListener(() => {
 	try{
 		// @ts-ignore
 		api.runtime?.getBrowserInfo().then(info => {
-			if(info.name == 'Firefox') {
+			if(/Firefox/.test(info.name)) {
 				api.storage.local.get({"canLoad": false}).then( val => {
 					if (!val) {
 						registerConsentScript();

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -3,7 +3,7 @@ import { defineManifest } from '@crxjs/vite-plugin';
 export default defineManifest({
 	name: 'Blue Blocker',
 	description: 'Blocks all Twitter Blue verified users on twitter.com',
-	version: '0.4.14',
+	version: '0.4.15',
 	manifest_version: 3,
 	icons: {
 		'128': 'icon/icon-128.png',


### PR DESCRIPTION
Two pretty silly bugs coincided to make it so firefox on android would load the consent popup would load every time the browser was opened. Closes #387 
